### PR TITLE
Added better null support for nullable value types, and non-nullable valu

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
+++ b/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
@@ -28,46 +28,92 @@ namespace ServiceStack.Text.Common
 			get { return CachedParseFn; }
 		}
 
+        private delegate T2 ParseDelegate<T2>(string val);
+
+        private static object ParseNullable<T3>(string val, ParseDelegate<T3> del)
+        {
+            if (val == null)
+                return null;
+            else
+                return (object)del(val);
+        }
+
+        private static object ParseNonNullable<T3>(string val, ParseDelegate<T3> del)
+        {
+            if (val == null)
+                return default(T3);
+            else
+                return (object)del(val);
+        }
+
 		private static ParseStringDelegate GetParseFn()
 		{
 			//Note the generic typeof(T) is faster than using var type = typeof(T)
-			if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
-				return value => bool.Parse(value);
-			if (typeof(T) == typeof(byte) || typeof(T) == typeof(byte?))
-				return value => byte.Parse(value);
-			if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(sbyte?))
-				return value => sbyte.Parse(value);
-			if (typeof(T) == typeof(short) || typeof(T) == typeof(short?))
-				return value => short.Parse(value);
-			if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
-				return value => int.Parse(value);
-			if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
-				return value => long.Parse(value);
-			if (typeof(T) == typeof(float) || typeof(T) == typeof(float?))
-				return value => float.Parse(value, CultureInfo.InvariantCulture);
-			if (typeof(T) == typeof(double) || typeof(T) == typeof(double?))
-				return value => double.Parse(value, CultureInfo.InvariantCulture);
-			if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
-				return value => decimal.Parse(value, CultureInfo.InvariantCulture);
+			if (typeof(T) == typeof(bool))
+				return value => ParseNonNullable(value,bool.Parse);
+            if (typeof(T) == typeof(bool?))
+                return value => ParseNullable(value, bool.Parse);
+			if (typeof(T) == typeof(byte))
+				return value => ParseNonNullable(value,byte.Parse);
+            if (typeof(T) == typeof(byte?))
+                return value => ParseNullable(value, byte.Parse);
+			if (typeof(T) == typeof(sbyte))
+                return value => ParseNonNullable(value,sbyte.Parse);
+            if (typeof(T) == typeof(sbyte?))
+                return value => ParseNullable(value, sbyte.Parse);
+			if (typeof(T) == typeof(short))
+				return value => ParseNonNullable(value,short.Parse);
+            if(typeof(T) == typeof(short?))
+                return value => ParseNullable(value, short.Parse);
+			if (typeof(T) == typeof(int))
+				return value => ParseNonNullable(value,int.Parse);
+            if (typeof(T) == typeof(int?))
+                return value => ParseNullable(value, int.Parse);
+            if (typeof(T) == typeof(long))
+                return value => ParseNonNullable(value, long.Parse);
+            if (typeof(T) == typeof(long?))
+                return value => ParseNullable(value, long.Parse);
+			if (typeof(T) == typeof(float))
+                return value => ParseNonNullable(value, x => float.Parse(x, CultureInfo.InvariantCulture));
+            if (typeof(T) == typeof(float?))
+                return value => ParseNullable(value, x =>  float.Parse(x, CultureInfo.InvariantCulture));
+			if (typeof(T) == typeof(double))
+				return value => ParseNonNullable(value, x => double.Parse(x, CultureInfo.InvariantCulture));
+            if (typeof(T) == typeof(double?))
+                return value => ParseNullable(value, x => double.Parse(x, CultureInfo.InvariantCulture));
+			if (typeof(T) == typeof(decimal))
+                return value => ParseNonNullable(value, x => decimal.Parse(x, CultureInfo.InvariantCulture));
+            if(typeof(T) == typeof(decimal?))
+                return value => ParseNullable(value, x => decimal.Parse(x, CultureInfo.InvariantCulture));
 
-			if (typeof(T) == typeof(Guid) || typeof(T) == typeof(Guid?))
+			if (typeof(T) == typeof(Guid))
 				return value => new Guid(value);
-			if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
+            if (typeof(T) == typeof(Guid?))
+                return value => ParseNullable(value, x => new Guid(x));
+			if (typeof(T) == typeof(DateTime))
 				return value => DateTimeSerializer.ParseShortestXsdDateTime(value);
+            if (typeof(T) == typeof(DateTime?))
+                return value => ParseNullable(value, DateTimeSerializer.ParseShortestXsdDateTime);
 			if (typeof(T) == typeof(TimeSpan) || typeof(T) == typeof(TimeSpan?))
-				return value => TimeSpan.Parse(value);
+				return value => value == null ? TimeSpan.Zero : TimeSpan.Parse(value);
 
 			if (typeof(T) == typeof(char) || typeof(T) == typeof(char?))
 			{
 				char cValue;
 				return value => char.TryParse(value, out cValue) ? cValue : '\0';
 			}
-			if (typeof(T) == typeof(ushort) || typeof(T) == typeof(ushort?))
-				return value => ushort.Parse(value);
-			if (typeof(T) == typeof(uint) || typeof(T) == typeof(uint?))
-				return value => uint.Parse(value);
-			if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
-				return value => ulong.Parse(value);
+			if (typeof(T) == typeof(ushort))
+				return value => ParseNonNullable(value,ushort.Parse);
+            if(typeof(T) == typeof(ushort?))
+                return value => ParseNullable(value,ushort.Parse);
+			if (typeof(T) == typeof(uint))
+				return value => ParseNonNullable(value,uint.Parse);
+            if(typeof(T) == typeof(uint?))
+                return value => ParseNullable(value, uint.Parse);
+            if (typeof(T) == typeof(ulong))
+                return value => ParseNonNullable(value, ulong.Parse);
+            if(typeof(T) == typeof(ulong?))
+                return value => ParseNullable(value, ulong.Parse);
 
 			return null;
 		}

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -99,7 +99,7 @@ namespace ServiceStack.Text.Tests.JsonTests
             JsConfig.IncludeNullValues = true;
             var s = JsonSerializer.SerializeToString(o);
             JsConfig.IncludeNullValues = false;
-            Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}"));
+            Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"NullableKey\":null,\"Nothing\":null}"));
         }
 
         [Test]
@@ -125,11 +125,21 @@ namespace ServiceStack.Text.Tests.JsonTests
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void Deserialize_throws_for_null_valuetypes()
+        public void Deserialize_sets_default_for_valuetypes()
         {
             var s = "{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":null}";
             var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
+
+            Assert.That(o.SampleKey, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Deserialize_sets_null_for_nullable_valuetypes()
+        {
+            var s = "{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"NullableKey\":null}";
+            var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
+
+            Assert.That(o.NullableKey, Is.Null);
         }
 
         private class NullValueTester
@@ -147,6 +157,12 @@ namespace ServiceStack.Text.Tests.JsonTests
             }
 
             public int SampleKey
+            {
+                get;
+                set;
+            }
+
+            public int? NullableKey
             {
                 get;
                 set;


### PR DESCRIPTION
Demis,
Thanks for ServiceStack.Text it's awesome. It's been a really useful alternative to Newtonsoft. I've added a couple of changes to better handle null support in this branch. Value types are now set to the default() for their type, unless they are nullable, in which case they are set to null. Hope that it's helpful. I added a unit test and modified another to check that things were working correctly.

Tom

PS I also have another branch develop-name-support in which I added the ability to remap a field using [DataMember(Name="field")]. This might be helpful too. I rolled those changes and these changes up under my develop branch, along with some other fixes.
