### PR TITLE
Make date/time parsing less error prone. DateTimeSerializer.ParseShortest

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -49,12 +49,7 @@ namespace ServiceStack.Text.Common
 				&& dateTimeStr.Length <= XsdDateTimeFormat.Length)
 				return XmlConvert.ToDateTime(dateTimeStr, XmlDateTimeSerializationMode.Local);
 
-			return new DateTime(
-				int.Parse(dateTimeStr.Substring(0, 4)),
-				int.Parse(dateTimeStr.Substring(5, 2)),
-				int.Parse(dateTimeStr.Substring(8, 2)),
-				0, 0, 0,
-				DateTimeKind.Local);
+			return DateTime.Parse(dateTimeStr, null, DateTimeStyles.AssumeLocal);
 		}
 
 		public static string ToDateTimeString(DateTime dateTime)

--- a/tests/ServiceStack.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -74,6 +74,13 @@ namespace ServiceStack.Text.Tests.Utils
 			AssertDateIsEqual(new DateTime(1979, 5, 9, 0, 0, 0, 1));
 			AssertDateIsEqual(new DateTime(2010, 10, 20, 10, 10, 10, 1));
 			AssertDateIsEqual(new DateTime(2010, 11, 22, 11, 11, 11, 1));
+			
+			DateTime shortDate = DateTimeSerializer.ParseShortestXsdDateTime("2011-8-4");
+			Assert.That (shortDate, Is.EqualTo(new DateTime (2011, 8, 4)), "Month and day without leading 0");
+			shortDate = DateTimeSerializer.ParseShortestXsdDateTime("2011-8-05");
+			Assert.That (shortDate, Is.EqualTo(new DateTime (2011, 8, 5)), "Month without leading 0");
+			shortDate = DateTimeSerializer.ParseShortestXsdDateTime("2011-09-4");
+			Assert.That (shortDate, Is.EqualTo(new DateTime (2011, 9, 4)), "Day without leading 0");
 		}
 
 		[Test]


### PR DESCRIPTION
Make date/time parsing less error prone. DateTimeSerializer.ParseShortestXsdDateTime to fail when it was
passed a date string which didn't match any of the patterns and didn't follow the YYYY-DD-MM format. This
happened, for instance, in the MovieRest example when updating any entries with date in the YYYY-D-M format
(e.g. the Interception). DateTime parser is pretty sophisitcated and it should be used instead of hand-crafted
code.
