### PR TITLE
Make Jsv and Json serializers honor IgnoreDataMemberAttribute.

### DIFF
--- a/src/ServiceStack.Text/ReflectionExtensions.cs
+++ b/src/ServiceStack.Text/ReflectionExtensions.cs
@@ -346,6 +346,7 @@ namespace ServiceStack.Text
 
 		const string DataContract = "DataContractAttribute";
 		const string DataMember = "DataMemberAttribute";
+		const string IgnoreDataMember = "IgnoreDataMemberAttribute";
 
 		public static PropertyInfo[] GetSerializableProperties(this Type type)
 		{
@@ -360,8 +361,8 @@ namespace ServiceStack.Text
 					attr.GetCustomAttributes(false).Any(x => x.GetType().Name == DataMember))
 					.ToArray();
 			}
-
-			return publicReadableProperties.ToArray();
+			// else return those properties that are not decorated with IgnoreDataMember
+			return publicReadableProperties.Where(prop => !prop.GetCustomAttributes(false).Any(attr => attr.GetType().Name == IgnoreDataMember)).ToArray();
 		}
 
 		public static bool IsDto(this Type type)

--- a/tests/ServiceStack.Text.Tests/DataContractTests.cs
+++ b/tests/ServiceStack.Text.Tests/DataContractTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NUnit.Framework;
@@ -22,6 +23,46 @@ namespace ServiceStack.Text.Tests
 
 			Serialize(dto);
 		}
+
+        public class RequestWithIgnoredMembers
+        {
+            public string Name { get; set; }
+
+            [IgnoreDataMember]
+            public string Comment { get; set; }
+        }
+
+        private void DoIgnoreMemberTest(Func<RequestWithIgnoredMembers, string> serialize, Func<string, RequestWithIgnoredMembers> deserialize)
+        {
+            var dto = new RequestWithIgnoredMembers()
+            {
+                Name = "John",
+                Comment = "Some Comment"
+            };
+
+            var clone = deserialize(serialize(dto));
+
+            Assert.AreEqual(dto.Name, clone.Name);
+            Assert.IsNull(clone.Comment);
+        }
+
+        [Test]
+        public void JsonSerializerHonorsIgnoreMemberAttribute()
+        {
+            DoIgnoreMemberTest(r => JsonSerializer.SerializeToString(r), s => JsonSerializer.DeserializeFromString<RequestWithIgnoredMembers>(s));
+        }
+
+        [Test]
+        public void JsvSerializerHonorsIgnoreMemberAttribute()
+        {
+            DoIgnoreMemberTest(r => TypeSerializer.SerializeToString(r), s => TypeSerializer.DeserializeFromString<RequestWithIgnoredMembers>(s));
+        }
+
+        [Test]
+        public void XmlSerializerHonorsIgnoreMemberAttribute()
+        {
+            DoIgnoreMemberTest(r => XmlSerializer.SerializeToString(r), s => XmlSerializer.DeserializeFromString<RequestWithIgnoredMembers>(s));
+        }
 
 		[DataContract]
 		public class EmptyDataContract


### PR DESCRIPTION
I noticed you have a comment that you do the attribute search by name instead of by Type to avoid dependency on Runtime.Serialization.  But I also notice that you have a reference to this DLL anyway.

Has this restriction on the dependency been lifted?  If so, I can modify the attribute search to go by Type, which I suspect is much faster.
