### PR TITLE
XmlSerializer.SerializeToWriter((object)someDto) fails SerializeToString((object)someDto) works

### DIFF
--- a/src/ServiceStack.Text/XmlSerializer.cs
+++ b/src/ServiceStack.Text/XmlSerializer.cs
@@ -104,13 +104,13 @@ namespace ServiceStack.Text
 			{
 				using (var xw = new XmlTextWriter(writer))
 				{
-					var serializer = new System.Runtime.Serialization.DataContractSerializer(typeof(T));
+					var serializer = new System.Runtime.Serialization.DataContractSerializer(value.GetType());
 					serializer.WriteObject(xw, value);
 				}
 			}
 			catch (Exception ex)
 			{
-				throw new SerializationException(string.Format("Error serializing object of type {0}", typeof(T).FullName), ex);
+                throw new SerializationException(string.Format("Error serializing object of type {0}", value.GetType().FullName), ex);
 			}
 		}
 

--- a/tests/ServiceStack.Text.Tests/AnonymousTypes.cs
+++ b/tests/ServiceStack.Text.Tests/AnonymousTypes.cs
@@ -11,7 +11,7 @@ namespace ServiceStack.Text.Tests
 		[Test]
 		public void Can_serialize_anonymous_types()
 		{
-			Serialize(new { Id = 1, Name = "Name", IntList = new[] { 1, 2, 3 } });
+			Serialize(new { Id = 1, Name = "Name", IntList = new[] { 1, 2, 3 } }, includeXml: false); // xmlserializer cannot serialize anonymous types.
 		}
 
 		[Test]

--- a/tests/ServiceStack.Text.Tests/ReportedIssues.cs
+++ b/tests/ServiceStack.Text.Tests/ReportedIssues.cs
@@ -54,7 +54,7 @@ namespace ServiceStack.Text.Tests
 				SomeObjectList = new object[0]
 			};
 
-			Serialize(obj);
+			Serialize(obj, includeXml: false); // xml cannot serialize Type objects.
 		}
 
 		[Test]
@@ -73,7 +73,7 @@ namespace ServiceStack.Text.Tests
 			var toModel = TypeSerializer.DeserializeFromString<TestObject>(strModel);
 		}
 
-		class Article
+		public class Article
 		{
 			public string title { get; set; }
 			public string url { get; set; }

--- a/tests/ServiceStack.Text.Tests/TestBase.cs
+++ b/tests/ServiceStack.Text.Tests/TestBase.cs
@@ -25,9 +25,9 @@ namespace ServiceStack.Text.Tests
 				Console.WriteLine(message);
 		}
 
-		public T Serialize<T>(T model)
+		public T Serialize<T>(T model, bool includeXml = true)
 		{
-			return Serialize(model, false);
+			return Serialize(model, false, includeXml);
 		}
 
 		public T JsonSerialize<T>(T model)
@@ -35,12 +35,12 @@ namespace ServiceStack.Text.Tests
 			return JsonSerialize(model, false);
 		}
 
-		public T SerializeAndCompare<T>(T model)
+		public T SerializeAndCompare<T>(T model, bool includeXml = true)
 		{
-			return Serialize(model, true);
+			return Serialize(model, true, includeXml);
 		}
 
-		private T Serialize<T>(T model, bool assertEqual)
+		private T Serialize<T>(T model, bool assertEqual, bool includeXml)
 		{
 			var stopwatch = Stopwatch.StartNew();
 			var jsv = TypeSerializer.SerializeToString(model);
@@ -55,6 +55,19 @@ namespace ServiceStack.Text.Tests
 
 			var partialJson = json.Length > 100 ? json.Substring(0, 100) + "..." : json;
 			Console.WriteLine("JSON Time: {0} ticks, Len: {1}: {2}", stopwatch.ElapsedTicks, json.Length, partialJson);
+
+            if (includeXml)
+            {
+                using (var xmlWriter = new System.IO.StringWriter())
+                {
+                    stopwatch = Stopwatch.StartNew();
+                    XmlSerializer.SerializeToWriter((object)model, xmlWriter);
+                    var xml = xmlWriter.ToString();
+                    stopwatch.Stop();
+                    var partialXml = xml.Length > 100 ? xml.Substring(0, 100) + "..." : xml;
+                    Console.WriteLine("XML Time: {0} ticks, Len: {1}: {2}", stopwatch.ElapsedTicks, xml.Length, partialXml);
+                }
+            }
 
 			var fromJsvModel = TypeSerializer.DeserializeFromString<T>(jsv);
 			var fromJsonModel = JsonSerializer.DeserializeFromString<T>(json);


### PR DESCRIPTION
Modified TestBase.Serialize() to test XmlSerializer as well.  Modified XmlSerializer.SerializeToWriter() to use value.GetType() instead of typeof(T) to match the semantics of the other XmlSerializer.SerializeTo... methods (and thus success in serializing when T == object).
