### PR TITLE
Bug in ReadOnlyCollection<> deserialization

### DIFF
--- a/tests/ServiceStack.Text.Tests/BasicStringSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/BasicStringSerializerTests.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Northwind.Common.ComplexModel;
 using NUnit.Framework;
 using ServiceStack.Common.Extensions;
 using ServiceStack.Common.Tests.Models;
-using System.Collections.Generic;
 using ServiceStack.Text.Common;
 
 namespace ServiceStack.Text.Tests
@@ -386,6 +386,33 @@ namespace ServiceStack.Text.Tests
 			var toHashSet = Serialize(fromHashSet);
 
 			Assert.That(toHashSet.EquivalentTo(fromHashSet), Is.True);
+		}
+
+		[Test]
+		public void Can_convert_string_to_string_ReadOnlyCollection()
+		{
+			var fromCollection = new ReadOnlyCollection<string>(stringValues);
+			var toCollection = Serialize(fromCollection);
+
+			Assert.That(toCollection.EquivalentTo(fromCollection), Is.True);
+		}
+
+		[Test]
+		public void Can_convert_string_to_int_ReadOnlyCollection()
+		{
+			var fromCollection = new ReadOnlyCollection<int>(intValues);
+			var toCollection = Serialize(fromCollection);
+
+			Assert.That(toCollection.EquivalentTo(fromCollection), Is.True);
+		}
+
+		[Test]
+		public void Can_convert_string_to_double_ReadOnlyCollection()
+		{
+			var fromCollection = new ReadOnlyCollection<double>(doubleValues);
+			var toCollection = Serialize(fromCollection);
+
+			Assert.That(toCollection.EquivalentTo(fromCollection), Is.True);
 		}
 
 		public T Serialize<T>(T model)


### PR DESCRIPTION
- wrote failing test cases for deserializing from a ReadOnlyCollection<T> (specifically int, string, double like those for HashSet)
- added ReadOnlyCollection<> check to DeSerializeListWithElement.ParseGenericList, since ReadOnlyCollection<> implements IList<>, but throws on .Add :( -- workaround for a poor design decision

Take a look at my TODO as the only way to construct a ReadOnlyCollection<T> is from an IList<T> as a constructor param.  I implemented with Activator.CreateInstance, but thought perhaps you should cache / compile Expressions (which coincidentally would work for Silverlight as well).

A good example of using static initializers to cache Expressions is in a Marc Gravell post here --
https://groups.google.com/forum/#!topic/microsoft.public.dotnet.languages.csharp/DZcipRsEMAo

Obviously, you'd want something like this instead, but the concepts are similar:

public static T New<T>(params object[] constructorParameters)
