### PR TITLE
Source code tweaks for MonoTouch + new MonoTouch-specific csproj

### DIFF
--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+#if !MONOTOUCH
 using System.Drawing;
+#endif
 using System.IO;
 using ServiceStack.Text.Common;
 using ServiceStack.Text.Json;
@@ -13,8 +15,10 @@ namespace ServiceStack.Text
 		static JsConfig()
 		{
 			//In-built defaults
+#if !MONOTOUCH
 			JsConfig<Color>.SerializeFn = c => c.ToString().Replace("Color ","").Replace("[","").Replace("]","");
 			JsConfig<Color>.DeSerializeFn = Color.FromName;
+#endif
 		}
 
 		[ThreadStatic]

--- a/src/ServiceStack.Text/ServiceStack.Text.MonoTouch.csproj
+++ b/src/ServiceStack.Text/ServiceStack.Text.MonoTouch.csproj
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{662AE06C-08DC-11E1-9759-BBBFD35946CCGUID@}</ProjectGuid>
+    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MonoTouchLibrary</RootNamespace>
+    <AssemblyName>ServiceStack.Text.dll</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\MonoTouch\Debug</OutputPath>
+    <DefineConstants>DEBUG;MONOTOUCH</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\MonoTouch\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <DefineConstants>MONOTOUCH</DefineConstants>
+    <GenerateDocumentation>true</GenerateDocumentation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="monotouch" />
+    <Reference Include="System.Runtime.Serialization" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Compile Include="StreamExtensions.cs" />
+    <Compile Include="StringExtensions.cs" />
+    <Compile Include="TextExtensions.cs" />
+    <Compile Include="Tracer.cs" />
+    <Compile Include="TranslateListWithElements.cs" />
+    <Compile Include="TypeConfig.cs" />
+    <Compile Include="TypeSerializer.cs" />
+    <Compile Include="TypeSerializer.Generic.cs" />
+    <Compile Include="XmlSerializer.cs" />
+    <Compile Include="Common\DateTimeSerializer.cs" />
+    <Compile Include="Common\DeserializeArray.cs" />
+    <Compile Include="Common\DeserializeBuiltin.cs" />
+    <Compile Include="Common\DeserializeCollection.cs" />
+    <Compile Include="Common\DeserializeDictionary.cs" />
+    <Compile Include="Common\DeserializeListWithElements.cs" />
+    <Compile Include="Common\DeserializeSpecializedCollections.cs" />
+    <Compile Include="Common\DeserializeType.cs" />
+    <Compile Include="Common\DeserializeTypeUtils.cs" />
+    <Compile Include="Common\ITypeSerializer.cs" />
+    <Compile Include="Common\JsDelegates.cs" />
+    <Compile Include="Common\JsReader.cs" />
+    <Compile Include="Common\JsState.cs" />
+    <Compile Include="Common\JsWriter.cs" />
+    <Compile Include="Common\ParseUtils.cs" />
+    <Compile Include="Common\StaticParseMethod.cs" />
+    <Compile Include="Common\WriteDictionary.cs" />
+    <Compile Include="Common\WriteLists.cs" />
+    <Compile Include="Common\WriteType.cs" />
+    <Compile Include="Controller\CommandProcessor.cs" />
+    <Compile Include="Controller\PathInfo.cs" />
+    <Compile Include="Json\JsonReader.Generic.cs" />
+    <Compile Include="Json\JsonTypeSerializer.cs" />
+    <Compile Include="Json\JsonUtils.cs" />
+    <Compile Include="Json\JsonWriter.Generic.cs" />
+    <Compile Include="Jsv\JsvDeserializeType.cs" />
+    <Compile Include="Jsv\JsvReader.Generic.cs" />
+    <Compile Include="Jsv\JsvSerializer.Generic.cs" />
+    <Compile Include="Jsv\JsvTypeSerializer.cs" />
+    <Compile Include="Jsv\JsvWriter.Generic.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Reflection\StaticAccessors.cs" />
+    <Compile Include="Support\AssemblyTypeDefinition.cs" />
+    <Compile Include="Support\DoubleConverter.cs" />
+    <Compile Include="Support\Link.cs" />
+    <Compile Include="Support\TypePair.cs" />
+    <Compile Include="AssemblyUtils.cs" />
+    <Compile Include="CsvConfig.cs" />
+    <Compile Include="CsvSerializer.cs" />
+    <Compile Include="CsvStreamExtensions.cs" />
+    <Compile Include="CsvWriter.cs" />
+    <Compile Include="DateTimeExtensions.cs" />
+    <Compile Include="Env.cs" />
+    <Compile Include="ITracer.cs" />
+    <Compile Include="ITypeSerializer.Generic.cs" />
+    <Compile Include="JsConfig.cs" />
+    <Compile Include="JsonObject.cs" />
+    <Compile Include="JsonSerializer.cs" />
+    <Compile Include="JsonSerializer.Generic.cs" />
+    <Compile Include="JsvFormatter.cs" />
+    <Compile Include="ListExtensions.cs" />
+    <Compile Include="MapExtensions.cs" />
+    <Compile Include="QueryStringSerializer.cs" />
+    <Compile Include="ReflectionExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/ServiceStack.Text/ServiceStack.Text.MonoTouch.sln
+++ b/src/ServiceStack.Text/ServiceStack.Text.MonoTouch.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Text.MonoTouch", "ServiceStack.Text.MonoTouch.csproj", "{662AE06C-08DC-11E1-9759-BBBFD35946CCGUID@}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{662AE06C-08DC-11E1-9759-BBBFD35946CCGUID@}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{662AE06C-08DC-11E1-9759-BBBFD35946CCGUID@}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{662AE06C-08DC-11E1-9759-BBBFD35946CCGUID@}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{662AE06C-08DC-11E1-9759-BBBFD35946CCGUID@}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = ServiceStack.Text.MonoTouch.csproj
+	EndGlobalSection
+EndGlobal

--- a/src/ServiceStack.Text/Support/DoubleConverter.cs
+++ b/src/ServiceStack.Text/Support/DoubleConverter.cs
@@ -68,7 +68,7 @@
 				exponent++;
 			}
 
-			/// Construct a new decimal expansion with the mantissa
+			// Construct a new decimal expansion with the mantissa
 			ArbitraryDecimal ad = new ArbitraryDecimal(mantissa);
 
 			// If the exponent is less than 0, we need to repeatedly


### PR DESCRIPTION
Greetings. I had some trouble with the v2.20 MonoTouch binaries (info at http://stackoverflow.com/questions/7942773/error-serializing-with-servicestack-json-on-monotouch/8032242). So I grabbed the latest source, but had to make a few minor changes. The new MonoTouch-specific csproj/sln may also be useful for others wanting to use a source reference instead of assembly reference in a MT project.

All I have tested is a very trivial example running on an iPad, but it did work.
