### PR TITLE
Fix to JSON serialising nulls in IDictionary<,>

### DIFF
--- a/src/ServiceStack.Text/Common/WriteDictionary.cs
+++ b/src/ServiceStack.Text/Common/WriteDictionary.cs
@@ -15,6 +15,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using ServiceStack.Text.Json;
 
 namespace ServiceStack.Text.Common
 {
@@ -149,6 +150,11 @@ namespace ServiceStack.Text.Common
 			var ranOnce = false;
 			foreach (var kvp in map)
 			{
+				bool isNull = (kvp.Value == null);
+
+				if ( isNull && !JsConfig.IncludeNullValues )
+					continue;
+				
 				JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);
 
 				JsState.WritingKeyCount++;
@@ -158,6 +164,12 @@ namespace ServiceStack.Text.Common
 
 				writer.Write(JsWriter.MapKeySeperator);
 
+				if ( isNull )
+				{
+					writer.Write(JsonUtils.Null);
+					continue;
+				}
+				
 				JsState.IsWritingValue = true;
 				writeValueFn(writer, kvp.Value);
 				JsState.IsWritingValue = false;

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -34,6 +34,28 @@ namespace ServiceStack.Text.Tests.JsonTests
 		}
 
 		[Test]
+		public void Can_serialise_null_values_from_dictionary_correctly()
+		{
+			JsConfig.IncludeNullValues = true;
+			var dictionary = new Dictionary<string,object> { { "value", null } };
+			var json = JsonSerializer.SerializeToString(dictionary);
+			Log(json);
+
+			Assert.That(json, Is.EqualTo("{\"value\":null}"));
+		}
+
+		[Test]
+		public void Will_ignore_null_values_from_dictionary_correctly()
+		{
+			JsConfig.IncludeNullValues = false;
+			var dictionary = new Dictionary<string,string> { { "value", null } };
+			var json = JsonSerializer.SerializeToString(dictionary);
+			Log(json);
+
+			Assert.That(json, Is.EqualTo("{}"));
+		}
+
+		[Test]
 		public void Can_handle_json_primitives()
 		{
 			var json = JsonSerializer.SerializeToString(JsonPrimitives.Create(1));


### PR DESCRIPTION
ServiceStack does not honour JsConfig.IncludeNullValues when serialising IDictionary<,> types and instead outputs invalid JSON.
