### PR TITLE
Improve Json Date Handling

### DIFF
--- a/src/ServiceStack.Text/DateTimeExtensions.cs
+++ b/src/ServiceStack.Text/DateTimeExtensions.cs
@@ -21,37 +21,42 @@ namespace ServiceStack.Text
 	public static class DateTimeExtensions
 	{
 		public const long UnixEpoch = 621355968000000000L;
-		private static readonly DateTime UnixEpochDateTime = new DateTime(UnixEpoch);
-
-		public const long TicksPerMs = TimeSpan.TicksPerSecond / 1000;
+		private static readonly DateTime UnixEpochDateTimeUtc = new DateTime(UnixEpoch, DateTimeKind.Utc);
+		private static readonly DateTime UnixEpochDateTimeUnspecified = new DateTime(UnixEpoch, DateTimeKind.Unspecified);
 
 		public static long ToUnixTime(this DateTime dateTime)
 		{
-			var epoch = (dateTime.ToUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerSecond;
-			return epoch;
+			return (dateTime.ToUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerSecond;
 		}
 
 		public static DateTime FromUnixTime(this double unixTime)
 		{
-			return UnixEpochDateTime + TimeSpan.FromSeconds(unixTime);
+			return UnixEpochDateTimeUtc + TimeSpan.FromSeconds(unixTime);
 		}
 
 		public static long ToUnixTimeMs(this DateTime dateTime)
 		{
-			var epoch = (dateTime.ToUniversalTime().Ticks - UnixEpoch) / TicksPerMs;
-			return epoch;
+			return (dateTime.ToUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerMillisecond;
 		}
 
 		public static DateTime FromUnixTimeMs(this double msSince1970)
 		{
-			var ticks = (long)(UnixEpoch + (msSince1970 * TicksPerMs));
-			return new DateTime(ticks, DateTimeKind.Utc).ToLocalTime();
+			return UnixEpochDateTimeUtc + TimeSpan.FromMilliseconds(msSince1970);
 		}
 
 		public static DateTime FromUnixTimeMs(this long msSince1970)
 		{
-			var ticks = UnixEpoch + (msSince1970 * TicksPerMs);
-			return new DateTime(ticks, DateTimeKind.Utc).ToLocalTime();
+			return UnixEpochDateTimeUtc + TimeSpan.FromMilliseconds(msSince1970);
+		}
+
+		public static DateTime FromUnixTimeMs(this long msSince1970, TimeSpan offset)
+		{
+			return UnixEpochDateTimeUnspecified + TimeSpan.FromMilliseconds(msSince1970) + offset;
+		}
+
+		public static DateTime FromUnixTimeMs(this double msSince1970, TimeSpan offset)
+		{
+			return UnixEpochDateTimeUnspecified + TimeSpan.FromMilliseconds(msSince1970) + offset;
 		}
 
 		public static DateTime FromUnixTimeMs(string msSince1970)
@@ -63,14 +68,23 @@ namespace ServiceStack.Text
 			return double.Parse(msSince1970).FromUnixTimeMs();
 		}
 
-        public static DateTime RoundToMs(this DateTime dateTime)
-        {
-            return new DateTime((dateTime.Ticks / TimeSpan.TicksPerMillisecond) * TimeSpan.TicksPerMillisecond);
-        }
+		public static DateTime FromUnixTimeMs(string msSince1970, TimeSpan offset)
+		{
+			long ms;
+			if (long.TryParse(msSince1970, out ms)) return ms.FromUnixTimeMs(offset);
+
+			// Do we really need to support fractional unix time ms time strings??
+			return double.Parse(msSince1970).FromUnixTimeMs(offset);
+		}
+
+		public static DateTime RoundToMs(this DateTime dateTime)
+		{
+			return new DateTime((dateTime.Ticks / TimeSpan.TicksPerMillisecond) * TimeSpan.TicksPerMillisecond);
+		}
 
 		public static DateTime RoundToSecond(this DateTime dateTime)
 		{
-			return new DateTime(((dateTime.Ticks) / TimeSpan.TicksPerSecond) * TimeSpan.TicksPerSecond);
+			return new DateTime((dateTime.Ticks / TimeSpan.TicksPerSecond) * TimeSpan.TicksPerSecond);
 		}
 
 		public static string ToShortestXsdDateTimeString(this DateTime dateTime)
@@ -86,6 +100,25 @@ namespace ServiceStack.Text
 		public static bool IsEqualToTheSecond(this DateTime dateTime, DateTime otherDateTime)
 		{
 			return dateTime.ToUniversalTime().RoundToSecond().Equals(otherDateTime.ToUniversalTime().RoundToSecond());
+		}
+
+		public static string ToTimeOffsetString(this TimeSpan offset, bool includeColon = false)
+		{
+			var sign = offset < TimeSpan.Zero ? "-" : "+";
+			var hours = Math.Abs(offset.Hours);
+			var minutes = Math.Abs(offset.Minutes);
+			var separator = includeColon ? ":" : "";
+			return string.Format("{0}{1:00}{2}{3:00}", sign, hours, separator, minutes);
+		}
+
+		public static TimeSpan FromTimeOffsetString(this string offsetString)
+		{
+			if (!offsetString.Contains(":"))
+				offsetString = offsetString.Insert(offsetString.Length - 2, ":");
+
+			offsetString = offsetString.TrimStart('+');
+
+			return TimeSpan.Parse(offsetString);
 		}
 	}
 }

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -7,57 +7,60 @@ using ServiceStack.Text.Jsv;
 
 namespace ServiceStack.Text
 {
-    public static class 
+	public static class
 		JsConfig
-    {
-        static JsConfig()
-        {
-            //In-built default serialization, to Deserialize Color struct do:
-            //JsConfig<System.Drawing.Color>.SerializeFn = c => c.ToString().Replace("Color ", "").Replace("[", "").Replace("]", "");
-            //JsConfig<System.Drawing.Color>.DeSerializeFn = System.Drawing.Color.FromName;
-        }
+	{
+		static JsConfig()
+		{
+			//In-built default serialization, to Deserialize Color struct do:
+			//JsConfig<System.Drawing.Color>.SerializeFn = c => c.ToString().Replace("Color ", "").Replace("[", "").Replace("]", "");
+			//JsConfig<System.Drawing.Color>.DeSerializeFn = System.Drawing.Color.FromName;
+		}
 
-        [ThreadStatic]
-        public static bool ConvertObjectTypesIntoStringDictionary = false;
+		[ThreadStatic]
+		public static bool ConvertObjectTypesIntoStringDictionary = false;
 
-        [ThreadStatic]
-        public static bool IncludeNullValues = false;
+		[ThreadStatic]
+		public static bool IncludeNullValues = false;
 
-        [ThreadStatic]
-        public static bool ExcludeTypeInfo = false;
+		[ThreadStatic]
+		public static bool ExcludeTypeInfo = false;
 
-        /// <summary>
-        /// <see langword="true"/> if the <see cref="ITypeSerializer"/> is configured
-        /// to take advantage of <see cref="CLSCompliantAttribute"/> specification,
-        /// to support user-friendly serialized formats, ie emitting camelCasing for JSON
-        /// and parsing member names and enum values in a case-insensitive manner.
-        /// </summary>
-        public static bool EmitCamelCaseNames
-        {
-            // obeying the use of ThreadStatic, but allowing for setting JsConfig once as is the normal case
-            get
-            {
-                return tsEmitCamelCaseNames ?? sEmitCamelCaseNames ?? false;
-            }
-            set
-            {
-                if (!tsEmitCamelCaseNames.HasValue) tsEmitCamelCaseNames = value;
-                if (!sEmitCamelCaseNames.HasValue) sEmitCamelCaseNames = value;
-            }
-        }
+		[ThreadStatic]
+		public static JsonDateHandler DateHandler = JsonDateHandler.TimestampOffset;
 
-        [ThreadStatic]
-        private static bool? tsEmitCamelCaseNames;
-        private static bool? sEmitCamelCaseNames;
+		/// <summary>
+		/// <see langword="true"/> if the <see cref="ITypeSerializer"/> is configured
+		/// to take advantage of <see cref="CLSCompliantAttribute"/> specification,
+		/// to support user-friendly serialized formats, ie emitting camelCasing for JSON
+		/// and parsing member names and enum values in a case-insensitive manner.
+		/// </summary>
+		public static bool EmitCamelCaseNames
+		{
+			// obeying the use of ThreadStatic, but allowing for setting JsConfig once as is the normal case
+			get
+			{
+				return tsEmitCamelCaseNames ?? sEmitCamelCaseNames ?? false;
+			}
+			set
+			{
+				if (!tsEmitCamelCaseNames.HasValue) tsEmitCamelCaseNames = value;
+				if (!sEmitCamelCaseNames.HasValue) sEmitCamelCaseNames = value;
+			}
+		}
 
-        internal static HashSet<Type> HasSerializeFn = new HashSet<Type>();
+		[ThreadStatic]
+		private static bool? tsEmitCamelCaseNames;
+		private static bool? sEmitCamelCaseNames;
 
-        public static void Reset()
-        {
-            ConvertObjectTypesIntoStringDictionary = IncludeNullValues = ExcludeTypeInfo = false;
-            tsEmitCamelCaseNames = sEmitCamelCaseNames = null;
-            HasSerializeFn = new HashSet<Type>();
-        }
+		internal static HashSet<Type> HasSerializeFn = new HashSet<Type>();
+
+		public static void Reset()
+		{
+			ConvertObjectTypesIntoStringDictionary = IncludeNullValues = ExcludeTypeInfo = false;
+			tsEmitCamelCaseNames = sEmitCamelCaseNames = null;
+			HasSerializeFn = new HashSet<Type>();
+		}
 
 #if SILVERLIGHT || MONOTOUCH
         /// <summary>
@@ -130,7 +133,7 @@ namespace ServiceStack.Text
         }
 #endif
 
-    }
+	}
 
 #if SILVERLIGHT || MONOTOUCH
     internal class Poco
@@ -216,59 +219,65 @@ namespace ServiceStack.Text
     }
 #endif
 
-    public class JsConfig<T> //where T : struct
-    {
-        /// <summary>
-        /// Never emit type info for this type
-        /// </summary>
-        public static bool ExcludeTypeInfo = false;
+	public class JsConfig<T> //where T : struct
+	{
+		/// <summary>
+		/// Never emit type info for this type
+		/// </summary>
+		public static bool ExcludeTypeInfo = false;
 
-        /// <summary>
-        /// <see langword="true"/> if the <see cref="ITypeSerializer"/> is configured
-        /// to take advantage of <see cref="CLSCompliantAttribute"/> specification,
-        /// to support user-friendly serialized formats, ie emitting camelCasing for JSON
-        /// and parsing member names and enum values in a case-insensitive manner.
-        /// </summary>
-        public static bool EmitCamelCaseNames = false;
+		/// <summary>
+		/// <see langword="true"/> if the <see cref="ITypeSerializer"/> is configured
+		/// to take advantage of <see cref="CLSCompliantAttribute"/> specification,
+		/// to support user-friendly serialized formats, ie emitting camelCasing for JSON
+		/// and parsing member names and enum values in a case-insensitive manner.
+		/// </summary>
+		public static bool EmitCamelCaseNames = false;
 
-        /// <summary>
-        /// Define custom serialization fn for BCL Structs
-        /// </summary>
-        private static Func<T, string> serializeFn;
-        public static Func<T, string> SerializeFn
-        {
-            get { return serializeFn; }
-            set
-            {
-                serializeFn = value;
-                if (value != null)
-                    JsConfig.HasSerializeFn.Add(typeof(T));
-                else
-                    JsConfig.HasSerializeFn.Remove(typeof(T));
-            }
-        }
+		/// <summary>
+		/// Define custom serialization fn for BCL Structs
+		/// </summary>
+		private static Func<T, string> serializeFn;
+		public static Func<T, string> SerializeFn
+		{
+			get { return serializeFn; }
+			set
+			{
+				serializeFn = value;
+				if (value != null)
+					JsConfig.HasSerializeFn.Add(typeof(T));
+				else
+					JsConfig.HasSerializeFn.Remove(typeof(T));
+			}
+		}
 
-        /// <summary>
-        /// Define custom deserialization fn for BCL Structs
-        /// </summary>
-        public static Func<string, T> DeSerializeFn;
+		/// <summary>
+		/// Define custom deserialization fn for BCL Structs
+		/// </summary>
+		public static Func<string, T> DeSerializeFn;
 
-        /// <summary>
-        /// Exclude specific properties of this type from being serialized
-        /// </summary>
-        public static string[] ExcludePropertyNames;
+		/// <summary>
+		/// Exclude specific properties of this type from being serialized
+		/// </summary>
+		public static string[] ExcludePropertyNames;
 
-        public static void WriteFn<TSerializer>(TextWriter writer, object obj)
-        {
-            var serializer = JsWriter.GetTypeSerializer<TSerializer>();
-            serializer.WriteString(writer, SerializeFn((T)obj));
-        }
+		public static void WriteFn<TSerializer>(TextWriter writer, object obj)
+		{
+			var serializer = JsWriter.GetTypeSerializer<TSerializer>();
+			serializer.WriteString(writer, SerializeFn((T)obj));
+		}
 
-        public static object ParseFn(string str)
-        {
-            return DeSerializeFn(str);
-        }
-    }
+		public static object ParseFn(string str)
+		{
+			return DeSerializeFn(str);
+		}
+	}
 
+	public enum JsonDateHandler
+	{
+		TimestampOffset,
+		DCJSCompatible,
+		ISO8601
+	}
 }
 

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -64,7 +64,7 @@ namespace ServiceStack.Text.Json
 
 		public void WritePropertyName(TextWriter writer, string value)
 		{
-			if (JsState.WritingKeyCount > 0) 
+			if (JsState.WritingKeyCount > 0)
 			{
 				writer.Write(JsWriter.EscapedQuoteString);
 				writer.Write(value);
@@ -102,12 +102,7 @@ namespace ServiceStack.Text.Json
 
 		public void WriteDateTime(TextWriter writer, object oDateTime)
 		{
-			//WriteRawString(writer, DateTimeSerializer.ToWcfJsonDate((DateTime)oDateTime));
-			writer.Write(JsWriter.QuoteChar);
-			writer.Write("\\/Date(");
-			writer.Write((((DateTime)oDateTime).ToUniversalTime().Ticks - DateTimeExtensions.UnixEpoch) / DateTimeExtensions.TicksPerMs);
-			writer.Write("+0000)\\/");
-			writer.Write(JsWriter.QuoteChar);
+			WriteRawString(writer, DateTimeSerializer.ToWcfJsonDate((DateTime)oDateTime));
 		}
 
 		public void WriteNullableDateTime(TextWriter writer, object dateTime)
@@ -136,56 +131,56 @@ namespace ServiceStack.Text.Json
 		public void WriteChar(TextWriter writer, object charValue)
 		{
 			if (charValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((char)charValue);
 		}
 
 		public void WriteByte(TextWriter writer, object byteValue)
 		{
 			if (byteValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((byte)byteValue);
 		}
 
 		public void WriteInt16(TextWriter writer, object intValue)
 		{
 			if (intValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((short)intValue);
 		}
 
 		public void WriteUInt16(TextWriter writer, object intValue)
 		{
 			if (intValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((ushort)intValue);
 		}
 
 		public void WriteInt32(TextWriter writer, object intValue)
 		{
 			if (intValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((int)intValue);
 		}
 
 		public void WriteUInt32(TextWriter writer, object uintValue)
 		{
 			if (uintValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((uint)uintValue);
 		}
 
 		public void WriteInt64(TextWriter writer, object integerValue)
 		{
 			if (integerValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write((long)integerValue);
 		}
 
@@ -193,8 +188,8 @@ namespace ServiceStack.Text.Json
 		{
 			if (ulongValue == null)
 			{
-                writer.Write(JsonUtils.Null);
-            }
+				writer.Write(JsonUtils.Null);
+			}
 			else
 				writer.Write((ulong)ulongValue);
 		}
@@ -202,18 +197,18 @@ namespace ServiceStack.Text.Json
 		public void WriteBool(TextWriter writer, object boolValue)
 		{
 			if (boolValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write(((bool)boolValue) ? JsonUtils.True : JsonUtils.False);
 		}
 
 		public void WriteFloat(TextWriter writer, object floatValue)
 		{
 			if (floatValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 			{
-				var floatVal = (float) floatValue;
+				var floatVal = (float)floatValue;
 				if (Equals(floatVal, float.MaxValue) || Equals(floatVal, float.MinValue))
 					writer.Write(floatVal.ToString("r", CultureInfo.InvariantCulture));
 				else
@@ -224,7 +219,7 @@ namespace ServiceStack.Text.Json
 		public void WriteDouble(TextWriter writer, object doubleValue)
 		{
 			if (doubleValue == null)
-                writer.Write(JsonUtils.Null);
+				writer.Write(JsonUtils.Null);
 			else
 			{
 				var doubleVal = (double)doubleValue;
@@ -238,24 +233,24 @@ namespace ServiceStack.Text.Json
 		public void WriteDecimal(TextWriter writer, object decimalValue)
 		{
 			if (decimalValue == null)
-                writer.Write(JsonUtils.Null);
-            else
+				writer.Write(JsonUtils.Null);
+			else
 				writer.Write(((decimal)decimalValue).ToString(CultureInfo.InvariantCulture));
 		}
 
-        public void WriteEnum(TextWriter writer, object enumValue)
-        {
-            if (enumValue == null) return;
-            WriteRawString(writer, enumValue.ToString());
-        }
+		public void WriteEnum(TextWriter writer, object enumValue)
+		{
+			if (enumValue == null) return;
+			WriteRawString(writer, enumValue.ToString());
+		}
 
-        public void WriteEnumFlags(TextWriter writer, object enumFlagValue)
-        {
-            if (enumFlagValue == null) return;
-            var intVal = (int)enumFlagValue;
-            writer.Write(intVal);
-        }
-		
+		public void WriteEnumFlags(TextWriter writer, object enumFlagValue)
+		{
+			if (enumFlagValue == null) return;
+			var intVal = (int)enumFlagValue;
+			writer.Write(intVal);
+		}
+
 		public ParseStringDelegate GetParseFn<T>()
 		{
 			return JsonReader.Instance.GetParseFn<T>();

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -29,7 +29,7 @@ namespace ServiceStack.Text.Tests.JsonTests
 					Float = i,
 					Double = i,
 					Boolean = i % 2 == 0,
-					DateTime = new DateTime(DateTimeExtensions.UnixEpoch + (i * DateTimeExtensions.TicksPerMs), DateTimeKind.Utc),
+					DateTime = DateTimeExtensions.FromUnixTimeMs(1),
 				};
 			}
 		}
@@ -41,7 +41,7 @@ namespace ServiceStack.Text.Tests.JsonTests
 			Log(json);
 
 			Assert.That(json, Is.EqualTo(
-				"{\"Int\":1,\"Long\":1,\"Float\":1,\"Double\":1,\"Boolean\":false,\"DateTime\":\"\\/Date(1+0000)\\/\"}"));
+				"{\"Int\":1,\"Long\":1,\"Float\":1,\"Double\":1,\"Boolean\":false,\"DateTime\":\"\\/Date(1)\\/\"}"));
 		}
 
 		[Test]
@@ -54,112 +54,112 @@ namespace ServiceStack.Text.Tests.JsonTests
 			Assert.That(value.NullString, Is.Null);
 		}
 
-        [Test]
-        public void Can_serialize_dictionary_of_int_int()
-        {
-            var json = JsonSerializer.SerializeToString<IntIntDictionary>(new IntIntDictionary() {Dictionary = {{10,100},{20,200}}});
-            const string expected = "{\"Dictionary\":{\"10\":100,\"20\":200}}";
-            Assert.That(json,Is.EqualTo(expected));
-        }
+		[Test]
+		public void Can_serialize_dictionary_of_int_int()
+		{
+			var json = JsonSerializer.SerializeToString<IntIntDictionary>(new IntIntDictionary() { Dictionary = { { 10, 100 }, { 20, 200 } } });
+			const string expected = "{\"Dictionary\":{\"10\":100,\"20\":200}}";
+			Assert.That(json, Is.EqualTo(expected));
+		}
 
-        private class IntIntDictionary
-        {
-            public IntIntDictionary()
-            {
-                Dictionary = new Dictionary<int, int>();
-            }
-            public IDictionary<int,int> Dictionary { get; set; }
-        }
+		private class IntIntDictionary
+		{
+			public IntIntDictionary()
+			{
+				Dictionary = new Dictionary<int, int>();
+			}
+			public IDictionary<int, int> Dictionary { get; set; }
+		}
 
-        [Test]
-        public void Serialize_skips_null_values_by_default()
-        {
-            var o = new NullValueTester
-            {
-                Name = "Brandon",
-                Type = "Programmer",
-                SampleKey = 12,
-                Nothing = (string)null
-            };
-            
-            var s = JsonSerializer.SerializeToString(o);
-            Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12}"));
-        }
+		[Test]
+		public void Serialize_skips_null_values_by_default()
+		{
+			var o = new NullValueTester
+			{
+				Name = "Brandon",
+				Type = "Programmer",
+				SampleKey = 12,
+				Nothing = (string)null
+			};
 
-        [Test]
-        public void Serialize_can_include_null_values()
-        {
-            var o = new NullValueTester
-            {
-                Name = "Brandon",
-                Type = "Programmer",
-                SampleKey = 12,
-                Nothing = null
-            };
-            
-            JsConfig.IncludeNullValues = true;
-            var s = JsonSerializer.SerializeToString(o);
-            JsConfig.IncludeNullValues = false;
-            Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}"));
-        }
+			var s = JsonSerializer.SerializeToString(o);
+			Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12}"));
+		}
 
-        [Test]
-        public void Deserialize_sets_null_values()
-        {
-            var s = "{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}";
-            var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
-            Assert.That(o.Name, Is.EqualTo("Brandon"));
-            Assert.That(o.Type, Is.EqualTo("Programmer"));
-            Assert.That(o.SampleKey, Is.EqualTo(12));
-            Assert.That(o.Nothing, Is.Null);
-        }
+		[Test]
+		public void Serialize_can_include_null_values()
+		{
+			var o = new NullValueTester
+			{
+				Name = "Brandon",
+				Type = "Programmer",
+				SampleKey = 12,
+				Nothing = null
+			};
 
-        [Test]
-        public void Deserialize_ignores_omitted_values()
-        {
-            var s = "{\"Type\":\"Programmer\",\"SampleKey\":2}";
-            var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
-            Assert.That(o.Name, Is.EqualTo("Miguel"));
-            Assert.That(o.Type, Is.EqualTo("Programmer"));
-            Assert.That(o.SampleKey, Is.EqualTo(2));
-            Assert.That(o.Nothing, Is.EqualTo("zilch"));
-        }
+			JsConfig.IncludeNullValues = true;
+			var s = JsonSerializer.SerializeToString(o);
+			JsConfig.IncludeNullValues = false;
+			Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}"));
+		}
 
-        private class NullValueTester
-        {
-            public string Name
-            {
-                get;
-                set;
-            }
+		[Test]
+		public void Deserialize_sets_null_values()
+		{
+			var s = "{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}";
+			var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
+			Assert.That(o.Name, Is.EqualTo("Brandon"));
+			Assert.That(o.Type, Is.EqualTo("Programmer"));
+			Assert.That(o.SampleKey, Is.EqualTo(12));
+			Assert.That(o.Nothing, Is.Null);
+		}
 
-            public string Type
-            {
-                get;
-                set;
-            }
+		[Test]
+		public void Deserialize_ignores_omitted_values()
+		{
+			var s = "{\"Type\":\"Programmer\",\"SampleKey\":2}";
+			var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
+			Assert.That(o.Name, Is.EqualTo("Miguel"));
+			Assert.That(o.Type, Is.EqualTo("Programmer"));
+			Assert.That(o.SampleKey, Is.EqualTo(2));
+			Assert.That(o.Nothing, Is.EqualTo("zilch"));
+		}
 
-            public int SampleKey
-            {
-                get;
-                set;
-            }
+		private class NullValueTester
+		{
+			public string Name
+			{
+				get;
+				set;
+			}
 
-            public string Nothing
-            {
-                get;
-                set;
-            }
+			public string Type
+			{
+				get;
+				set;
+			}
 
-            public NullValueTester()
-            {
-                Name = "Miguel";
-                Type = "User";
-                SampleKey = 1;
-                Nothing = "zilch";
-            }
-        }
-		
+			public int SampleKey
+			{
+				get;
+				set;
+			}
+
+			public string Nothing
+			{
+				get;
+				set;
+			}
+
+			public NullValueTester()
+			{
+				Name = "Miguel";
+				Type = "User";
+				SampleKey = 1;
+				Nothing = "zilch";
+			}
+		}
+
 		[DataContract]
 		class Person
 		{
@@ -172,7 +172,8 @@ namespace ServiceStack.Text.Tests.JsonTests
 		[Test]
 		public void Can_override_name()
 		{
-			var person = new Person {
+			var person = new Person
+			{
 				Id = 123,
 				Name = "Abc"
 			};

--- a/tests/ServiceStack.Text.Tests/JsonTests/CamelCaseTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/CamelCaseTests.cs
@@ -24,13 +24,14 @@ namespace ServiceStack.Text.Tests.JsonTests
 		[Test]
 		public void Does_serialize_To_CamelCase()
 		{
-			var dto = new Movie {
+			var dto = new Movie
+			{
 				Id = 1,
 				ImdbId = "tt0111161",
 				Title = "The Shawshank Redemption",
 				Rating = 9.2m,
 				Director = "Frank Darabont",
-				ReleaseDate = new DateTime(1995, 2, 17),
+				ReleaseDate = new DateTime(1995, 2, 17, 0, 0, 0, DateTimeKind.Utc),
 				TagLine = "Fear can hold you prisoner. Hope can set you free.",
 				Genres = new List<string> { "Crime", "Drama" },
 			};
@@ -38,7 +39,7 @@ namespace ServiceStack.Text.Tests.JsonTests
 			var json = dto.ToJson();
 
 			Assert.That(json, Is.EqualTo(
-				"{\"id\":1,\"imdbId\":\"tt0111161\",\"title\":\"The Shawshank Redemption\",\"rating\":9.2,\"director\":\"Frank Darabont\",\"releaseDate\":\"\\/Date(792997200000+0000)\\/\",\"tagLine\":\"Fear can hold you prisoner. Hope can set you free.\",\"genres\":[\"Crime\",\"Drama\"]}"));
+				"{\"id\":1,\"imdbId\":\"tt0111161\",\"title\":\"The Shawshank Redemption\",\"rating\":9.2,\"director\":\"Frank Darabont\",\"releaseDate\":\"\\/Date(792979200000)\\/\",\"tagLine\":\"Fear can hold you prisoner. Hope can set you free.\",\"genres\":[\"Crime\",\"Drama\"]}"));
 
 			Serialize(dto);
 		}
@@ -55,7 +56,8 @@ namespace ServiceStack.Text.Tests.JsonTests
 		[Test]
 		public void Can_override_name()
 		{
-			var person = new Person {
+			var person = new Person
+			{
 				Id = 123,
 				Name = "Abc"
 			};

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDataContractCompatibilityTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDataContractCompatibilityTests.cs
@@ -14,7 +14,7 @@ namespace ServiceStack.Text.Tests.JsonTests
 		[Test]
 		public void Can_serialize_a_movie()
 		{
-			const string clientJson = "{\"Id\":\"tt0110912\",\"Title\":\"Pulp Fiction\",\"Rating\":\"8.9\",\"Director\":\"Quentin Tarantino\",\"ReleaseDate\":\"/Date(785635200000+0000)/\",\"TagLine\":\"Girls like me don't make invitations like this to just anyone!\",\"Genres\":[\"Crime\",\"Drama\",\"Thriller\"]}";
+			const string clientJson = "{\"Id\":\"tt0110912\",\"Title\":\"Pulp Fiction\",\"Rating\":\"8.9\",\"Director\":\"Quentin Tarantino\",\"ReleaseDate\":\"/Date(785635200000)/\",\"TagLine\":\"Girls like me don't make invitations like this to just anyone!\",\"Genres\":[\"Crime\",\"Drama\",\"Thriller\"]}";
 			var jsonModel = JsonSerializer.DeserializeFromString<Movie>(clientJson);
 			var bclJsonModel = BclJsonDataContractDeserializer.Instance.Parse<Movie>(clientJson);
 
@@ -25,33 +25,6 @@ namespace ServiceStack.Text.Tests.JsonTests
 			Console.WriteLine("CLIENT {0}\nSS {1}\nBCL {2}", clientJson, ssJson, wcfJson);
 
 			Assert.That(jsonModel, Is.EqualTo(bclJsonModel));
-		}
-
-		[Test, Ignore("Known descrepancy, Leave UTC DateTimes without TZ Info")]
-		public void Can_serialize_WcfJsonDate()
-		{
-			//1994/11/24
-			var releaseDate = new DateTime(1994, 11, 24);
-			var ssJson = JsonSerializer.SerializeToString(releaseDate);
-			var bclJson = BclJsonDataContractSerializer.Instance.Parse(releaseDate);
-
-			//Console.WriteLine("Ticks: {0}", releaseDate.Ticks); 
-			//Console.WriteLine("UnixEpoch: {0}", DateTimeExtensions.UnixEpoch);
-			//Console.WriteLine("TicksPerMs: {0}", TimeSpan.TicksPerSecond / 1000);
-			//Console.WriteLine("Ticks - UnixEpoch: {0}", releaseDate.Ticks - DateTimeExtensions.UnixEpoch);
-			//Console.WriteLine("{0} == {1}", ssJson, bclJson);
-
-			Assert.That(ssJson, Is.EqualTo(bclJson));
-		}
-
-		[Test]
-		public void Can_deserialize_json_date()
-		{
-			var releaseDate = new DateTime(1994, 11, 24);
-			var ssJson = JsonSerializer.SerializeToString(releaseDate);
-			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(ssJson);
-
-			Assert.That(fromJson, Is.EqualTo(releaseDate));
 		}
 
 		[Test]

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using NUnit.Framework;
+using ServiceStack.Client;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+	public class JsonDateTimeTests
+	{
+		#region TimestampOffset Tests
+		[Test]
+		public void Can_serialize_json_date_timestampOffset_utc()
+		{
+			JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Utc);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+
+			Assert.That(ssJson, Is.EqualTo(@"""\/Date(785635200000)\/"""));
+		}
+
+		[Test]
+		public void Can_serialize_json_date_timestampOffset_local()
+		{
+			JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Local);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+
+			var offsetSpan = TimeZoneInfo.Local.GetUtcOffset(dateTime);
+			var ticks = 785635200000 - offsetSpan.TotalMilliseconds;
+			var offset = offsetSpan.ToTimeOffsetString();
+
+			Assert.That(ssJson, Is.EqualTo(@"""\/Date(" + ticks + offset + @")\/"""));
+		}
+
+		[Test]
+		public void Can_serialize_json_date_timestampOffset_unspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+
+			// Unspecified time is assumed to be local, so just make sure they serialize the same way.
+
+			var dateTime1 = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Unspecified);
+			var ssJson1 = JsonSerializer.SerializeToString(dateTime1);
+
+			var dateTime2 = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Local);
+			var ssJson2 = JsonSerializer.SerializeToString(dateTime2);
+
+			Assert.That(ssJson1, Is.EqualTo(ssJson2));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_timestampOffset_withoutOffset_asUtc()
+		{
+			JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+
+			const string json = @"""\/Date(785635200000)\/""";
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Utc);
+			Assert.That(fromJson, Is.EqualTo(dateTime));
+			Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_timestampOffset_withOffset_asUnspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+
+			const string json = @"""\/Date(785660400000-0700)\/""";
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Unspecified);
+			Assert.That(fromJson, Is.EqualTo(dateTime));
+			Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_timestampOffset_withZeroOffset_asUnspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+
+			const string json = @"""\/Date(785635200000+0000)\/""";
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Unspecified);
+			Assert.That(fromJson, Is.EqualTo(dateTime));
+			Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
+		}
+
+		#endregion
+
+		#region DCJS Compatibility Tests
+		[Test]
+		public void Can_serialize_json_date_dcjsCompatible_utc()
+		{
+			JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Utc);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+			var bclJson = BclJsonDataContractSerializer.Instance.Parse(dateTime);
+
+			Assert.That(ssJson, Is.EqualTo(bclJson));
+		}
+
+		[Test]
+		public void Can_serialize_json_date_dcjsCompatible_local()
+		{
+			JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Local);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+			var bclJson = BclJsonDataContractSerializer.Instance.Parse(dateTime);
+
+			Assert.That(ssJson, Is.EqualTo(bclJson));
+		}
+
+		[Test]
+		public void Can_serialize_json_date_dcjsCompatible_unspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Unspecified);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+			var bclJson = BclJsonDataContractSerializer.Instance.Parse(dateTime);
+
+			Assert.That(ssJson, Is.EqualTo(bclJson));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_dcjsCompatible_utc()
+		{
+			JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Utc);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(ssJson);
+			var fromBclJson = BclJsonDataContractDeserializer.Instance.Parse<DateTime>(ssJson);
+
+			Assert.That(fromJson, Is.EqualTo(fromBclJson));
+			Assert.That(fromJson.Kind, Is.EqualTo(fromBclJson.Kind));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_dcjsCompatible_local()
+		{
+			JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Local);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(ssJson);
+			var fromBclJson = BclJsonDataContractDeserializer.Instance.Parse<DateTime>(ssJson);
+
+			Assert.That(fromJson, Is.EqualTo(fromBclJson));
+			Assert.That(fromJson.Kind, Is.EqualTo(fromBclJson.Kind));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_dcjsCompatible_unspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+
+			var dateTime = new DateTime(1994, 11, 24, 0, 0, 0, DateTimeKind.Unspecified);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(ssJson);
+			var fromBclJson = BclJsonDataContractDeserializer.Instance.Parse<DateTime>(ssJson);
+
+			Assert.That(fromJson, Is.EqualTo(fromBclJson));
+			Assert.That(fromJson.Kind, Is.EqualTo(fromBclJson.Kind));
+		}
+		#endregion
+
+		#region ISO-8601 Tests
+		[Test]
+		public void Can_serialize_json_date_iso8601_utc()
+		{
+			JsConfig.DateHandler = JsonDateHandler.ISO8601;
+
+			var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Utc);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+
+			Assert.That(ssJson, Is.EqualTo(@"""\/Date(1994-11-24T12:34:56.0000000Z)\/"""));
+		}
+
+		[Test]
+		public void Can_serialize_json_date_iso8601_local()
+		{
+			JsConfig.DateHandler = JsonDateHandler.ISO8601;
+
+			var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Local);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+
+			var offsetSpan = TimeZoneInfo.Local.GetUtcOffset(dateTime);
+			var offset = offsetSpan.ToTimeOffsetString(true);
+
+			Assert.That(ssJson, Is.EqualTo(@"""\/Date(1994-11-24T12:34:56.0000000" + offset + @")\/"""));
+		}
+
+		[Test]
+		public void Can_serialize_json_date_iso8601_unspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.ISO8601;
+
+			var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Unspecified);
+			var ssJson = JsonSerializer.SerializeToString(dateTime);
+
+			Assert.That(ssJson, Is.EqualTo(@"""\/Date(1994-11-24T12:34:56.0000000)\/"""));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_iso8601_withZOffset_asUtc()
+		{
+			JsConfig.DateHandler = JsonDateHandler.ISO8601;
+
+			const string json = @"""\/Date(1994-11-24T12:34:56Z)\/""";
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+			var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Utc);
+			Assert.That(fromJson, Is.EqualTo(dateTime));
+			Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_iso8601_withoutOffset_asUnspecified()
+		{
+			JsConfig.DateHandler = JsonDateHandler.ISO8601;
+
+			const string json = @"""\/Date(1994-11-24T12:34:56)\/""";
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+			var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Unspecified);
+			Assert.That(fromJson, Is.EqualTo(dateTime));
+			Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
+		}
+
+		[Test]
+		public void Can_deserialize_json_date_iso8601_withOffset_asLocal()
+		{
+			JsConfig.DateHandler = JsonDateHandler.ISO8601;
+
+			var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Local);
+			var offset = TimeZoneInfo.Local.GetUtcOffset(dateTime).ToTimeOffsetString(true);
+
+			var json = @"""\/Date(1994-11-24T12:34:56" + offset + @")\/""";
+			var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+
+			Assert.That(fromJson, Is.EqualTo(dateTime));
+			Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
+		}
+
+		#endregion
+	}
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="CsvSerializerTests.cs" />
     <Compile Include="CsvStreamTests.cs" />
     <Compile Include="CsvTests\CustomHeaderTests.cs" />
+    <Compile Include="JsonTests\JsonDateTimeTests.cs" />
     <Compile Include="JsonTests\PolymorphicListTests.cs" />
     <Compile Include="JsvTests\JsvDeserializeTypeTest.cs" />
     <Compile Include="MessagingTests.cs" />


### PR DESCRIPTION
Made several improvements to how dates are handled in JSON.  There are three modes of operation, which can be set by JsConfig.DateHandler.

JsonDateHandler.TimestampOffset:
- is the default option.
- uses the format Date(timestamp+offset)
- properly interprets the offset and produces output with DateTime.Kind = Unspecified
- when no offset is provided, the output has DateTime.Kind = Utc

JsonDateHandler.DCJSCompatible:
- has exact parity with DataContractJsonSerializer
- works mostly the same as TimestampOffset, but treats any time with an offset as DateTime.Kind = Local
- ignores the actual offset, just like DCJS does

JsonDateHandler.ISO8601:
- uses the format Date(yyyy-mm-ddThh:mm:ss.fffffzzz)
- aligns with the ISO8601 date format
- implemented by the "o" format specifier - a.k.a. the "Round-Trip Date Pattern"
