### PR TITLE
Type.GetType fails with typeName argument in silverlight

### DIFF
--- a/src/ServiceStack.Text/AssemblyUtils.cs
+++ b/src/ServiceStack.Text/AssemblyUtils.cs
@@ -28,9 +28,10 @@ namespace ServiceStack.Text
         /// <returns></returns>
         public static Type FindType(string typeName)
         {
+#if !SILVERLIGHT
             var type = Type.GetType(typeName);
             if (type != null) return type;
-
+#endif
             var typeDef = new AssemblyTypeDefinition(typeName);
             if (!String.IsNullOrEmpty(typeDef.AssemblyName))
             {


### PR DESCRIPTION
(incorrect format). More info here: http://stackoverflow.com/questions/3068131/how-to-load-a-type-from-a-referenced-assembly-at-runtime-using-a-string-in-silv

The code below still handles type resolution.
