### PR TITLE
Added tests and support for the DefaultValue attribute

### DIFF
--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -11,6 +11,7 @@
 //
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using ServiceStack.Text.Json;
@@ -108,10 +109,11 @@ namespace ServiceStack.Text.Common
 					propertyNameCLSFriendly = propertyName.ToCamelCase();
 				}
 
-			    var propertyType = propertyInfo.PropertyType;
-			    var suppressDefaultValue = propertyType.IsValueType && JsConfig.HasSerializeFn.Contains(propertyType)
-			        ? ReflectionExtensions.GetDefaultValue(propertyType)
-			        : null;
+                var propertyType = propertyInfo.PropertyType;
+                var defaultValueAttibute = propertyInfo.GetCustomAttributes(typeof(DefaultValueAttribute), false).FirstOrDefault() as DefaultValueAttribute;
+                var suppressDefaultValue = propertyType.IsValueType && JsConfig.HasSerializeFn.Contains(propertyType)
+                    ? ReflectionExtensions.GetDefaultValue(propertyType)
+                    : defaultValueAttibute != null ? defaultValueAttibute.Value : null;
 
 				PropertyWriters[i] = new TypePropertyWriter
 				(

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -1,190 +1,242 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 using NUnit.Framework;
 using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.Text.Tests.JsonTests
 {
-	[TestFixture]
-	public class BasicJsonTests
-		: TestBase
-	{
-		public class JsonPrimitives
-		{
-			public int Int { get; set; }
-			public long Long { get; set; }
-			public float Float { get; set; }
-			public double Double { get; set; }
-			public bool Boolean { get; set; }
-			public DateTime DateTime { get; set; }
-			public string NullString { get; set; }
+    [TestFixture]
+    public class BasicJsonTests
+        : TestBase
+    {
+        public class JsonPrimitives
+        {
+            public int Int { get; set; }
+            public long Long { get; set; }
+            public float Float { get; set; }
+            public double Double { get; set; }
+            public bool Boolean { get; set; }
+            public DateTime DateTime { get; set; }
+            public string NullString { get; set; }
 
-			public static JsonPrimitives Create(int i)
-			{
-				return new JsonPrimitives
-				{
-					Int = i,
-					Long = i,
-					Float = i,
-					Double = i,
-					Boolean = i % 2 == 0,
-					DateTime = DateTimeExtensions.FromUnixTimeMs(1),
-				};
-			}
-		}
+            public static JsonPrimitives Create(int i)
+            {
+                return new JsonPrimitives
+                {
+                    Int = i,
+                    Long = i,
+                    Float = i,
+                    Double = i,
+                    Boolean = i % 2 == 0,
+                    DateTime = DateTimeExtensions.FromUnixTimeMs(1),
+                };
+            }
+        }
 
-		[Test]
-		public void Can_handle_json_primitives()
-		{
-			var json = JsonSerializer.SerializeToString(JsonPrimitives.Create(1));
-			Log(json);
+        [Test]
+        public void Can_handle_json_primitives()
+        {
+            var json = JsonSerializer.SerializeToString(JsonPrimitives.Create(1));
+            Log(json);
 
-			Assert.That(json, Is.EqualTo(
-				"{\"Int\":1,\"Long\":1,\"Float\":1,\"Double\":1,\"Boolean\":false,\"DateTime\":\"\\/Date(1)\\/\"}"));
-		}
+            Assert.That(json, Is.EqualTo(
+                "{\"Int\":1,\"Long\":1,\"Float\":1,\"Double\":1,\"Boolean\":false,\"DateTime\":\"\\/Date(1)\\/\"}"));
+        }
 
-		[Test]
-		public void Can_parse_json_with_nulls()
-		{
-			const string json = "{\"Int\":1,\"NullString\":null}";
-			var value = JsonSerializer.DeserializeFromString<JsonPrimitives>(json);
+        [Test]
+        public void Can_parse_json_with_nulls()
+        {
+            const string json = "{\"Int\":1,\"NullString\":null}";
+            var value = JsonSerializer.DeserializeFromString<JsonPrimitives>(json);
 
-			Assert.That(value.Int, Is.EqualTo(1));
-			Assert.That(value.NullString, Is.Null);
-		}
+            Assert.That(value.Int, Is.EqualTo(1));
+            Assert.That(value.NullString, Is.Null);
+        }
 
-		[Test]
-		public void Can_serialize_dictionary_of_int_int()
-		{
-			var json = JsonSerializer.SerializeToString<IntIntDictionary>(new IntIntDictionary() { Dictionary = { { 10, 100 }, { 20, 200 } } });
-			const string expected = "{\"Dictionary\":{\"10\":100,\"20\":200}}";
-			Assert.That(json, Is.EqualTo(expected));
-		}
+        [Test]
+        public void Can_serialize_dictionary_of_int_int()
+        {
+            var json = JsonSerializer.SerializeToString<IntIntDictionary>(new IntIntDictionary() { Dictionary = { { 10, 100 }, { 20, 200 } } });
+            const string expected = "{\"Dictionary\":{\"10\":100,\"20\":200}}";
+            Assert.That(json, Is.EqualTo(expected));
+        }
 
-		private class IntIntDictionary
-		{
-			public IntIntDictionary()
-			{
-				Dictionary = new Dictionary<int, int>();
-			}
-			public IDictionary<int, int> Dictionary { get; set; }
-		}
+        private class IntIntDictionary
+        {
+            public IntIntDictionary()
+            {
+                Dictionary = new Dictionary<int, int>();
+            }
+            public IDictionary<int, int> Dictionary { get; set; }
+        }
 
-		[Test]
-		public void Serialize_skips_null_values_by_default()
-		{
-			var o = new NullValueTester
-			{
-				Name = "Brandon",
-				Type = "Programmer",
-				SampleKey = 12,
-				Nothing = (string)null,
-				NullableDateTime = null
-			};
+        [Test]
+        public void Serialize_skips_null_values_by_default()
+        {
+            var o = new NullValueTester
+            {
+                Name = "Brandon",
+                Type = "Programmer",
+                SampleKey = 12,
+                Nothing = (string)null,
+                NullableDateTime = null
+            };
 
-			var s = JsonSerializer.SerializeToString(o);
-			Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12}"));
-		}
+            var s = JsonSerializer.SerializeToString(o);
+            Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12}"));
+        }
 
-		[Test]
-		public void Serialize_can_include_null_values()
-		{
-			var o = new NullValueTester
-			{
-				Name = "Brandon",
-				Type = "Programmer",
-				SampleKey = 12,
-				Nothing = null,
-				NullableDateTime = null
-			};
+        [Test]
+        public void Serialize_can_include_null_values()
+        {
+            var o = new NullValueTester
+            {
+                Name = "Brandon",
+                Type = "Programmer",
+                SampleKey = 12,
+                Nothing = null,
+                NullableDateTime = null
+            };
 
-			JsConfig.IncludeNullValues = true;
-			var s = JsonSerializer.SerializeToString(o);
-			JsConfig.Reset();
-			Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null,\"NullableDateTime\":null}"));
-		}
+            JsConfig.IncludeNullValues = true;
+            var s = JsonSerializer.SerializeToString(o);
+            JsConfig.Reset();
+            Assert.That(s, Is.EqualTo("{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null,\"NullableDateTime\":null}"));
+        }
 
-		[Test]
-		public void Deserialize_sets_null_values()
-		{
-			var s = "{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}";
-			var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
-			Assert.That(o.Name, Is.EqualTo("Brandon"));
-			Assert.That(o.Type, Is.EqualTo("Programmer"));
-			Assert.That(o.SampleKey, Is.EqualTo(12));
-			Assert.That(o.Nothing, Is.Null);
-		}
+        [Test]
+        public void Deserialize_sets_null_values()
+        {
+            var s = "{\"Name\":\"Brandon\",\"Type\":\"Programmer\",\"SampleKey\":12,\"Nothing\":null}";
+            var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
+            Assert.That(o.Name, Is.EqualTo("Brandon"));
+            Assert.That(o.Type, Is.EqualTo("Programmer"));
+            Assert.That(o.SampleKey, Is.EqualTo(12));
+            Assert.That(o.Nothing, Is.Null);
+        }
 
-		[Test]
-		public void Deserialize_ignores_omitted_values()
-		{
-			var s = "{\"Type\":\"Programmer\",\"SampleKey\":2}";
-			var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
-			Assert.That(o.Name, Is.EqualTo("Miguel"));
-			Assert.That(o.Type, Is.EqualTo("Programmer"));
-			Assert.That(o.SampleKey, Is.EqualTo(2));
-			Assert.That(o.Nothing, Is.EqualTo("zilch"));
-		}
+        [Test]
+        public void Deserialize_ignores_omitted_values()
+        {
+            var s = "{\"Type\":\"Programmer\",\"SampleKey\":2}";
+            var o = JsonSerializer.DeserializeFromString<NullValueTester>(s);
+            Assert.That(o.Name, Is.EqualTo("Miguel"));
+            Assert.That(o.Type, Is.EqualTo("Programmer"));
+            Assert.That(o.SampleKey, Is.EqualTo(2));
+            Assert.That(o.Nothing, Is.EqualTo("zilch"));
+        }
 
-		private class NullValueTester
-		{
-			public string Name
-			{
-				get;
-				set;
-			}
+        private class NullValueTester
+        {
+            public string Name
+            {
+                get;
+                set;
+            }
 
-			public string Type
-			{
-				get;
-				set;
-			}
+            public string Type
+            {
+                get;
+                set;
+            }
 
-			public int SampleKey
-			{
-				get;
-				set;
-			}
+            public int SampleKey
+            {
+                get;
+                set;
+            }
 
-			public string Nothing
-			{
-				get;
-				set;
-			}
+            public string Nothing
+            {
+                get;
+                set;
+            }
 
-			public DateTime? NullableDateTime { get; set; }
+            public DateTime? NullableDateTime { get; set; }
 
-			public NullValueTester()
-			{
-				Name = "Miguel";
-				Type = "User";
-				SampleKey = 1;
-				Nothing = "zilch";
-				NullableDateTime = new DateTime(2012, 01, 01);
-			}
-		}
+            public NullValueTester()
+            {
+                Name = "Miguel";
+                Type = "User";
+                SampleKey = 1;
+                Nothing = "zilch";
+                NullableDateTime = new DateTime(2012, 01, 01);
+            }
+        }
 
-		[DataContract]
-		class Person
-		{
-			[DataMember(Name = "MyID")]
-			public int Id { get; set; }
-			[DataMember]
-			public string Name { get; set; }
-		}
+        [DataContract]
+        class Person
+        {
+            [DataMember(Name = "MyID")]
+            public int Id { get; set; }
+            [DataMember]
+            public string Name { get; set; }
+        }
 
-		[Test]
-		public void Can_override_name()
-		{
-			var person = new Person
-			{
-				Id = 123,
-				Name = "Abc"
-			};
+        [Test]
+        public void Can_override_name()
+        {
+            var person = new Person
+            {
+                Id = 123,
+                Name = "Abc"
+            };
 
-			Assert.That(TypeSerializer.SerializeToString(person), Is.EqualTo("{MyID:123,Name:Abc}"));
-			Assert.That(JsonSerializer.SerializeToString(person), Is.EqualTo("{\"MyID\":123,\"Name\":\"Abc\"}"));
-		}
-	}
+            Assert.That(TypeSerializer.SerializeToString(person), Is.EqualTo("{MyID:123,Name:Abc}"));
+            Assert.That(JsonSerializer.SerializeToString(person), Is.EqualTo("{\"MyID\":123,\"Name\":\"Abc\"}"));
+        }
+
+        class DefaultValueTestClass
+        {
+            public DefaultValueTestClass()
+            {
+                Id = 0;
+                IsDefault = false;
+                Text = string.Empty;
+            }
+
+            [DefaultValue(0)]
+            public int Id { get; set; }
+
+            [DefaultValue(false)]
+            public bool IsDefault { get; set; }
+
+            [DefaultValueAttribute("")]
+            public string Text { get; set; }
+        }
+
+
+        [Test]
+        public void Serialize_ignores_default_value()
+        {
+            var testClass = new DefaultValueTestClass();
+
+            var serialisedString = TypeSerializer.SerializeToString(testClass);
+
+            var deserializedClass = TypeSerializer.DeserializeFromString<DefaultValueTestClass>(serialisedString);
+            Assert.That(deserializedClass.Id, Is.EqualTo(testClass.Id));
+            Assert.That(deserializedClass.IsDefault, Is.EqualTo(testClass.IsDefault));
+            Assert.That(deserializedClass.Text, Is.EqualTo(testClass.Text));
+           
+            Assert.That(serialisedString, Is.EqualTo("{}"));
+        }
+
+        [Test]
+        public void Serialize_doesnt_ignore_non_default_value()
+        {
+            var testClass = new DefaultValueTestClass { Id = 1, IsDefault = true };
+
+            var serialisedString = TypeSerializer.SerializeToString(testClass);
+
+            var deserializedClass = TypeSerializer.DeserializeFromString<DefaultValueTestClass>(serialisedString);
+            Assert.That(deserializedClass.Id, Is.EqualTo(testClass.Id));
+            Assert.That(deserializedClass.IsDefault, Is.EqualTo(testClass.IsDefault));
+            Assert.That(deserializedClass.Text, Is.EqualTo(testClass.Text));
+            
+            Assert.That(serialisedString, Is.EqualTo("{Id:1,IsDefault:True}"));
+
+        }
+    }
 }


### PR DESCRIPTION
I've only just started using ServiceStack.Text and am looking at it to replace xml serialization.

I've noticed that many of the value type fields within the objects I'm serializing are set to their defaults, and those fields are still in the output stream.

Take for example the following class

```
class DefaultValueTestClass
{
    public DefaultValueTestClass()
    {
        Id = 0;
        IsDefault = false;
        Text = string.Empty;
    }

    public int Id { get; set; }
    public bool IsDefault { get; set; }
    public string Text { get; set; }
}
```

serializing a default instance would result in a serialized output of 

```
{Id:0,IsDefault:false,Text:}
```

If the fields specified their default values, ie.

```
{
    [DefaultValue(0)]
    public int Id { get; set;}

    [DefaultValue(false)]
    public bool IsDefault { get; set; }

    [DefaultValue("")]
    public string Text { get; set; }
}
```

then the serialized output would be

```
{}
```
