### PR TITLE
Fix of deserializing nullable datetimes

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -31,7 +31,15 @@ namespace ServiceStack.Text.Common
 		public const string WcfJsonPrefix = "/Date(";
 		public const char WcfJsonSuffix = ')';
 
-		public static DateTime ParseShortestXsdDateTime(string dateTimeStr)
+        public static DateTime? ParseShortestNullableXsdDateTime(string dateTimeStr)
+        {
+            if (dateTimeStr == null)
+                return null;
+
+            return ParseShortestXsdDateTime(dateTimeStr);
+        }
+
+	    public static DateTime ParseShortestXsdDateTime(string dateTimeStr)
 		{
 			if (string.IsNullOrEmpty(dateTimeStr))
 				return DateTime.MinValue;

--- a/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
+++ b/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
@@ -52,8 +52,10 @@ namespace ServiceStack.Text.Common
 
 			if (typeof(T) == typeof(Guid))
 				return value => new Guid(value);
-			if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
-				return value => DateTimeSerializer.ParseShortestXsdDateTime(value);
+			if (typeof(T) == typeof(DateTime?))
+				return value => DateTimeSerializer.ParseShortestNullableXsdDateTime(value);
+            if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
+                return value => DateTimeSerializer.ParseShortestXsdDateTime(value);
 			if (typeof(T) == typeof(DateTimeOffset) || typeof(T) == typeof(DateTimeOffset?))
 				return value => DateTimeSerializer.ParseDateTimeOffset(value);
 			if (typeof(T) == typeof(TimeSpan))

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -34,6 +34,61 @@ namespace ServiceStack.Text.Tests.JsonTests
 			}
 		}
 
+        public class NullableValueTypes
+        {
+            public int? Int { get; set; }
+            public long? Long { get; set; }
+            public decimal? Decimal { get; set; }
+            public double? Double { get; set; }
+            public bool? Boolean { get; set; }
+            public DateTime? DateTime { get; set; }
+        }
+
+	    [Test]
+	    public void Can_parse_json_with_nullable_valuetypes()
+	    {
+	        var json = "{}";
+
+            var item = JsonSerializer.DeserializeFromString<NullableValueTypes>(json);
+
+            Assert.That(item.Int, Is.Null, "int");
+            Assert.That(item.Long, Is.Null, "long");
+            Assert.That(item.Decimal, Is.Null, "decimal");
+            Assert.That(item.Double, Is.Null, "double");
+            Assert.That(item.Boolean, Is.Null, "boolean");
+            Assert.That(item.DateTime, Is.Null, "datetime");
+	    }
+
+        [Test]
+        public void Can_parse_json_with_nullable_valuetypes_that_has_included_null_values()
+        {
+            var json = "{\"Int\":null,\"Long\":null,\"Decimal\":null,\"Double\":null,\"Boolean\":null,\"DateTime\":null}";
+
+            var item = JsonSerializer.DeserializeFromString<NullableValueTypes>(json);
+
+            Assert.That(item.Int, Is.Null, "int");
+            Assert.That(item.Long, Is.Null, "long");
+            Assert.That(item.Decimal, Is.Null, "decimal");
+            Assert.That(item.Double, Is.Null, "double");
+            Assert.That(item.Boolean, Is.Null, "boolean");
+            Assert.That(item.DateTime, Is.Null, "datetime");
+        }
+
+        [Test]
+        public void Can_parse_json_with_nullable_valuetypes_that_has_no_value_specified()
+        {
+            var json = "{\"Int\":,\"Long\":,\"Decimal\":,\"Double\":,\"Boolean\":,\"DateTime\":}";
+
+            var item = JsonSerializer.DeserializeFromString<NullableValueTypes>(json);
+
+            Assert.That(item.Int, Is.Null, "int");
+            Assert.That(item.Long, Is.Null, "long");
+            Assert.That(item.Decimal, Is.Null, "decimal");
+            Assert.That(item.Double, Is.Null, "double");
+            Assert.That(item.Boolean, Is.Null, "boolean");
+            Assert.That(item.DateTime, Is.Null, "datetime");
+        }
+
 		[Test]
 		public void Can_handle_json_primitives()
 		{


### PR DESCRIPTION
When model has nullable datetime and JSON contains null value or missing value it was deserialized to DateTime.MinValue.

Fixed to deserialize to Null instead.

//Daniel
