### PR TITLE
Serializing to Dictionary<string,string> double quotes property names

### DIFF
--- a/tests/ServiceStack.Text.Tests/ReportedIssues.cs
+++ b/tests/ServiceStack.Text.Tests/ReportedIssues.cs
@@ -206,5 +206,31 @@ namespace ServiceStack.Text.Tests
 			Serialize(dto);
 		}
 
+        [Test]
+        public void Objects_Do_Not_Survive_RoundTrips_Via_StringStringDictionary_Due_To_DoubleQuoted_Properties()
+        {
+            var book = new Book();
+            book.Id = 1234;
+            book.Title = "ServiceStack in Action";
+            book.CategoryId = 16;
+            book.Description = "Manning eBooks";
+
+
+            var json = book.ToJson();
+            Console.WriteLine("Book to Json: " + json);
+
+            var dictionary = json.To<Dictionary<string, string>>();
+            Console.WriteLine("Json to Dictionary: " + dictionary.Dump());
+
+            var fromDictionary = dictionary.ToJson();
+            Console.WriteLine("Json from Dictionary: " + fromDictionary);
+
+            var fromJsonViaDictionary = fromDictionary.To<Book>();
+
+            Assert.AreEqual(book.Description, fromJsonViaDictionary.Description);
+            Assert.AreEqual(book.Id, fromJsonViaDictionary.Id);
+            Assert.AreEqual(book.Title, fromJsonViaDictionary.Title);
+            Assert.AreEqual(book.CategoryId, fromJsonViaDictionary.CategoryId);
+        }
 	}
 }


### PR DESCRIPTION
I noticed a regression in ServiceStack.Redis - RedisClient.StoreAsHash<T>(T entity) and RedisClient.GetFromHash<T>(object id) both rely on objects surviving serialization roundtrips via Dictionary<string,string> as below:

```
    public T GetFromHash<T>(object id)
    {
        var key = IdUtils.CreateUrn<T>(id);
        return
            GetAllEntriesFromHash(key).ToJson().FromJson<T>();
    }

    public void StoreAsHash<T>(T entity)
    {
        var key = string.Format(entity.CreateUrn());
        SetRangeInHash(key, entity.ToJson().To<Dictionary<string, string>>());
        RegisterTypeId(entity);
    }
```

I have attached a failing test that shows when converting to Dictionary<string,string>, the property names get wrapped in double quotes. I think this has changed recently - is this a bug or working as-designed?
-Dan
