### PR TITLE
fixes for non-ISO8601 DateTime support

### DIFF
--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -28,7 +28,7 @@ namespace ServiceStack.Text
 			}
 			set
 			{
-				if (!tsConvertObjectTypesIntoStringDictionary.HasValue) tsConvertObjectTypesIntoStringDictionary = value;
+				tsConvertObjectTypesIntoStringDictionary = value;
 				if (!sConvertObjectTypesIntoStringDictionary.HasValue) sConvertObjectTypesIntoStringDictionary = value;
 			}
 		}
@@ -44,7 +44,7 @@ namespace ServiceStack.Text
 			}
 			set
 			{
-				if (!tsIncludeNullValues.HasValue) tsIncludeNullValues = value;
+				tsIncludeNullValues = value;
 				if (!sIncludeNullValues.HasValue) sIncludeNullValues = value;
 			}
 		}
@@ -60,7 +60,7 @@ namespace ServiceStack.Text
 			}
 			set
 			{
-				if (!tsExcludeTypeInfo.HasValue) tsExcludeTypeInfo = value;
+				tsExcludeTypeInfo = value;
 				if (!sExcludeTypeInfo.HasValue) sExcludeTypeInfo = value;
 			}
 		}
@@ -76,7 +76,7 @@ namespace ServiceStack.Text
 			}
 			set
 			{
-				if (!tsDateHandler.HasValue) tsDateHandler = value;
+				tsDateHandler = value;
 				if (!sDateHandler.HasValue) sDateHandler = value;
 			}
 		}
@@ -100,7 +100,7 @@ namespace ServiceStack.Text
 			}
 			set
 			{
-				if (!tsEmitCamelCaseNames.HasValue) tsEmitCamelCaseNames = value;
+				tsEmitCamelCaseNames = value;
 				if (!sEmitCamelCaseNames.HasValue) sEmitCamelCaseNames = value;
 			}
 		}
@@ -122,8 +122,7 @@ namespace ServiceStack.Text
 			}
 			set
 			{
-				bool theValue = value;
-				if (!tsThrowOnDeserializationError.HasValue) tsThrowOnDeserializationError = value;
+				tsThrowOnDeserializationError = value;
 				if (!sThrowOnDeserializationError.HasValue) sThrowOnDeserializationError = value;
 			}
 		}

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -334,5 +334,48 @@ namespace ServiceStack.Text.Tests.JsonTests
 			JsConfig.Reset();
 		}
 		#endregion
-	}
+
+        #region InteropTests
+
+        [Test]
+        public void Can_serialize_DCJSCompatible_deserialize_ISO8601()
+        {
+            var dateTimeOffset = new DateTimeOffset(1994, 11, 24, 12, 34, 56, TimeSpan.FromHours(-7));
+
+            JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+            var json = ServiceStack.Text.Common.DateTimeSerializer.ToWcfJsonDateTimeOffset(dateTimeOffset);
+
+            JsConfig.DateHandler = JsonDateHandler.ISO8601;
+            var fromJson = ServiceStack.Text.Common.DateTimeSerializer.ParseDateTimeOffset(json);
+
+            Assert.That(fromJson, Is.EqualTo(dateTimeOffset));
+            JsConfig.Reset();
+        }
+
+        [Test]
+        public void Can_serialize_ISO8601_deserialize_DCJSCompatible()
+        {
+            var dateTimeOffset = new DateTimeOffset(1994, 11, 24, 12, 34, 56, TimeSpan.FromHours(-7));
+
+            JsConfig.DateHandler = JsonDateHandler.ISO8601;
+            var json = ServiceStack.Text.Common.DateTimeSerializer.ToWcfJsonDateTimeOffset(dateTimeOffset);
+
+            JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+            var fromJson = ServiceStack.Text.Common.DateTimeSerializer.ParseDateTimeOffset(json);
+            
+            Assert.That(fromJson, Is.EqualTo(dateTimeOffset));
+            JsConfig.Reset();
+        }
+
+        [Test]
+        public void Can_deserialize_null()
+        {
+            const string json = (string)null;
+            var expected = default(DateTimeOffset);
+            var fromJson = ServiceStack.Text.Common.DateTimeSerializer.ParseDateTimeOffset(json);
+            Assert.That(fromJson, Is.EqualTo(expected));
+        }
+
+        #endregion
+    }
 }


### PR DESCRIPTION
fixed DateTimeOffset support for non-ISO8601 formats, changed parse behavior of datetime to not use config (bad for interop), and included interop tests.
