### PR TITLE
DateTimeOffset fixes

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -80,11 +80,7 @@ namespace ServiceStack.Text.Common
             // format: prefer TimestampOffset, DCJSCompatible
             if (dateTimeOffsetStr.StartsWith(EscapedWcfJsonPrefix))
             {
-                var fromJson = new DateTimeOffset(ParseWcfJsonDate(dateTimeOffsetStr));
-                // shifty Daylight Savings Time
-                var shift = TimeZoneInfo.Local.BaseUtcOffset - TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
-                fromJson = new DateTimeOffset(fromJson.DateTime + shift, fromJson.Offset - shift);
-                return fromJson;
+                return ParseWcfJsonDateOffset(dateTimeOffsetStr);
             }
 
             // format: next preference ISO8601
@@ -120,6 +116,51 @@ namespace ServiceStack.Text.Common
 
 
 		static readonly char[] TimeZoneChars = new[] { '+', '-' };
+
+		/// <summary>
+		/// WCF Json format: /Date(unixts+0000)/
+		/// </summary>
+		/// <param name="wcfJsonDate"></param>
+		/// <returns></returns>
+		public static DateTimeOffset ParseWcfJsonDateOffset(string wcfJsonDate)
+		{
+			if (wcfJsonDate[0] == '\\')
+			{
+				wcfJsonDate = wcfJsonDate.Substring(1);
+			}
+
+			var suffixPos = wcfJsonDate.IndexOf(WcfJsonSuffix);
+			var timeString = (suffixPos < 0) ? wcfJsonDate : wcfJsonDate.Substring(WcfJsonPrefix.Length, suffixPos - WcfJsonPrefix.Length);
+
+			// for interop, do not assume format based on config
+			if (!wcfJsonDate.StartsWith(WcfJsonPrefix))
+			{
+				return DateTimeOffset.Parse(timeString, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+			}
+
+			var timeZonePos = timeString.LastIndexOfAny(TimeZoneChars);
+			var timeZone = timeZonePos <= 0 ? string.Empty : timeString.Substring(timeZonePos);
+			var unixTimeString = timeString.Substring(0, timeString.Length - timeZone.Length);
+
+			var unixTime = long.Parse(unixTimeString);
+
+			if (timeZone == string.Empty)
+			{
+				// when no timezone offset is supplied, then treat the time as UTC
+				return unixTime.FromUnixTimeMs();
+			}
+
+			if (JsConfig.DateHandler == JsonDateHandler.DCJSCompatible)
+			{
+				// DCJS ignores the offset and considers it local time if any offset exists
+				// REVIEW: DCJS shoves offset in a separate field 'offsetMinutes', we have the offset in the format, so shouldn't we use it?
+				return unixTime.FromUnixTimeMs().ToLocalTime();
+			}
+
+			var offset = timeZone.FromTimeOffsetString();
+			var date = unixTime.FromUnixTimeMs().ToLocalTime();
+			return new DateTimeOffset(date.Ticks, offset);
+		}
 
 		/// <summary>
 		/// WCF Json format: /Date(unixts+0000)/

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -338,11 +338,11 @@ namespace ServiceStack.Text.Tests.JsonTests
         #region InteropTests
 
         [Test]
-        public void Can_serialize_DCJSCompatible_deserialize_ISO8601()
+        public void Can_serialize_TimestampOffset_deserialize_ISO8601()
         {
-            var dateTimeOffset = new DateTimeOffset(1994, 11, 24, 12, 34, 56, TimeSpan.FromHours(-7));
+            var dateTimeOffset = new DateTimeOffset(1997, 11, 24, 12, 34, 56, TimeSpan.FromHours(-10));
 
-            JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+            JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
             var json = ServiceStack.Text.Common.DateTimeSerializer.ToWcfJsonDateTimeOffset(dateTimeOffset);
 
             JsConfig.DateHandler = JsonDateHandler.ISO8601;
@@ -355,14 +355,15 @@ namespace ServiceStack.Text.Tests.JsonTests
         [Test]
         public void Can_serialize_ISO8601_deserialize_DCJSCompatible()
         {
-            var dateTimeOffset = new DateTimeOffset(1994, 11, 24, 12, 34, 56, TimeSpan.FromHours(-7));
+            var dateTimeOffset = new DateTimeOffset(1994, 11, 24, 12, 34, 56, TimeSpan.FromHours(-10));
 
             JsConfig.DateHandler = JsonDateHandler.ISO8601;
             var json = ServiceStack.Text.Common.DateTimeSerializer.ToWcfJsonDateTimeOffset(dateTimeOffset);
 
             JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
             var fromJson = ServiceStack.Text.Common.DateTimeSerializer.ParseDateTimeOffset(json);
-            
+
+            // NOTE: DJCS goes to local, so botches offset
             Assert.That(fromJson, Is.EqualTo(dateTimeOffset));
             JsConfig.Reset();
         }


### PR DESCRIPTION
Previously only worked symmetrically for ISO8601 format.  Interop tests between ISO8601 and DCJS formats flushed out minor issues, which are here fixed.

Also in testing needing to switch the config flushed out the JsConfig ThreadStatic values not allowing rewrite.  This is not intended, the most local storage of the static values should be rewriteable, so this has been fixed.
