### PR TITLE
Broke under .NET, detecting Mono and setting format accordingly.

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -158,7 +158,8 @@ namespace ServiceStack.Text.Common
             if (!propertyInfo.CanWrite)
             {
                 //TODO: What string comparison is used in SST?
-                var fieldName = string.Format("<{0}>", propertyInfo.Name);
+				string fieldNameFormat = Env.IsMono ? "<{0}>" : "<{0}>i__Field";
+                var fieldName = string.Format(fieldNameFormat, propertyInfo.Name);
                 var fieldInfos = typeConfig.Type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField);
                 foreach (var f in fieldInfos)
                 {


### PR DESCRIPTION
Should fix the test failing under .NET.
