### PR TITLE
ISO 8601 (Nullable)TimeSpans to be (de)serialised from json

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -96,10 +96,32 @@ namespace ServiceStack.Text.Common
 			return XmlConvert.ToString(dateTime.ToStableUniversalTime(), XmlDateTimeSerializationMode.Utc);
 		}
 
+        public static string ToXsdTimeSpanString(TimeSpan timeSpan)
+        {
+            return XmlConvert.ToString(timeSpan);
+        }
+
+        public static string ToXsdTimeSpanString(TimeSpan? timeSpan)
+        {
+            return (timeSpan != null) ? XmlConvert.ToString(timeSpan.Value) : null;
+        }
+
 		public static DateTime ParseXsdDateTime(string dateTimeStr)
 		{
 			return XmlConvert.ToDateTime(dateTimeStr, XmlDateTimeSerializationMode.Utc);
 		}
+
+        public static TimeSpan ParseXsdTimeSpan(string dateTimeStr)
+        {
+            return XmlConvert.ToTimeSpan(dateTimeStr);
+        }
+
+        public static TimeSpan? ParseXsdNullableTimeSpan(string dateTimeStr)
+        {
+            return String.IsNullOrEmpty(dateTimeStr) ? 
+                null :
+                new TimeSpan?(XmlConvert.ToTimeSpan(dateTimeStr));
+        }
 
 		public static string ToShortestXsdDateTimeString(DateTime dateTime)
 		{

--- a/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
+++ b/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
@@ -58,8 +58,10 @@ namespace ServiceStack.Text.Common
                 return value => DateTimeSerializer.ParseShortestXsdDateTime(value);
 			if (typeof(T) == typeof(DateTimeOffset) || typeof(T) == typeof(DateTimeOffset?))
 				return value => DateTimeSerializer.ParseDateTimeOffset(value);
-			if (typeof(T) == typeof(TimeSpan))
-				return value => TimeSpan.Parse(value);
+            if (typeof(T) == typeof(TimeSpan))
+                return value => DateTimeSerializer.ParseXsdTimeSpan(value);
+			if (typeof(T) == typeof(TimeSpan?))
+                return value => DateTimeSerializer.ParseXsdNullableTimeSpan(value);
 #if !MONOTOUCH && !SILVERLIGHT && !XBOX
 			if (typeof(T) == typeof(System.Data.Linq.Binary))
 				return value => new System.Data.Linq.Binary(Convert.FromBase64String(value));

--- a/src/ServiceStack.Text/Common/ITypeSerializer.cs
+++ b/src/ServiceStack.Text/Common/ITypeSerializer.cs
@@ -23,6 +23,8 @@ namespace ServiceStack.Text.Common
 		void WriteNullableDateTime(TextWriter writer, object dateTime);
 		void WriteDateTimeOffset(TextWriter writer, object oDateTimeOffset);
 		void WriteNullableDateTimeOffset(TextWriter writer, object dateTimeOffset);
+        void WriteTimeSpan(TextWriter writer, object dateTimeOffset);
+        void WriteNullableTimeSpan(TextWriter writer, object dateTimeOffset);
 		void WriteGuid(TextWriter writer, object oValue);
 		void WriteNullableGuid(TextWriter writer, object oValue);
 		void WriteBytes(TextWriter writer, object oByteValue);

--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -171,6 +171,12 @@ namespace ServiceStack.Text.Common
 			if (type == typeof(DateTimeOffset?))
 				return Serializer.WriteNullableDateTimeOffset;
 
+            if (type == typeof(TimeSpan))
+                return Serializer.WriteTimeSpan;
+
+            if (type == typeof(TimeSpan?))
+                return Serializer.WriteNullableTimeSpan;
+
             if (type == typeof(Guid))
                 return Serializer.WriteGuid;
 

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -126,6 +126,17 @@ namespace ServiceStack.Text.Json
 				WriteDateTimeOffset(writer, dateTimeOffset);
 		}
 
+        public void WriteTimeSpan(TextWriter writer, object oTimeSpan)
+        {
+            writer.Write(DateTimeSerializer.ToXsdTimeSpanString((TimeSpan)oTimeSpan));
+        }
+
+        public void WriteNullableTimeSpan(TextWriter writer, object oTimeSpan)
+        {
+            if (oTimeSpan == null) return;
+            writer.Write(DateTimeSerializer.ToXsdTimeSpanString((TimeSpan?)oTimeSpan));
+        }
+
 		public void WriteGuid(TextWriter writer, object oValue)
 		{
 			WriteRawString(writer, ((Guid)oValue).ToString("N"));

--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -97,6 +97,17 @@ namespace ServiceStack.Text.Jsv
 			this.WriteDateTimeOffset(writer, dateTimeOffset);
 		}
 
+        public void WriteTimeSpan(TextWriter writer, object oTimeSpan)
+        {
+            writer.Write(DateTimeSerializer.ToXsdTimeSpanString((TimeSpan)oTimeSpan));
+        }
+
+        public void WriteNullableTimeSpan(TextWriter writer, object oTimeSpan)
+        {
+            if (oTimeSpan == null) return;
+            writer.Write(DateTimeSerializer.ToXsdTimeSpanString((TimeSpan?)oTimeSpan));
+        }
+
 		public void WriteGuid(TextWriter writer, object oValue)
 		{
 			writer.Write(((Guid)oValue).ToString("N"));

--- a/tests/ServiceStack.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -21,6 +21,12 @@ namespace ServiceStack.Text.Tests.Utils
 			Log("\n");
 		}
 
+        public void PrintFormats(TimeSpan timeSpan)
+        {
+            Log("DateTimeSerializer.ToXsdTimeSpanString(timeSpan): " + DateTimeSerializer.ToXsdTimeSpanString(timeSpan));
+            Log("\n");
+        }
+
 		[Test]
 		public void PrintDate()
 		{
@@ -32,6 +38,15 @@ namespace ServiceStack.Text.Tests.Utils
 			PrintFormats(new DateTime(2010, 10, 20, 10, 10, 10, 1));
 			PrintFormats(new DateTime(2010, 11, 22, 11, 11, 11, 1));
 		}
+
+        [Test]
+        public void PrintTimeSpan()
+        {
+            PrintFormats(new TimeSpan());
+            PrintFormats(new TimeSpan(1));
+            PrintFormats(new TimeSpan(1, 2, 3));
+            PrintFormats(new TimeSpan(1, 2, 3, 4));
+        }
 
 		[Test]
 		public void ToShortestXsdDateTimeString_works()


### PR DESCRIPTION
Added support for (Nullable)TimeSpans to be (de)serialised from json in ISO 8601.

Browser support isn't widely available for that format yet - but I'm not sure the current .net outputted timespan is either.
