### PR TITLE
Minor fixes to DateTime serialization and JSV serializer

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
@@ -5,111 +5,100 @@ using ServiceStack.Text.Jsv;
 
 namespace ServiceStack.Text.Common
 {
-	internal static class DeserializeTypeRefJsv
-	{
-		private static readonly JsvTypeSerializer Serializer = (JsvTypeSerializer)JsvTypeSerializer.Instance;
+    internal static class DeserializeTypeRefJsv
+    {
+        private static readonly JsvTypeSerializer Serializer = (JsvTypeSerializer)JsvTypeSerializer.Instance;
 
-		internal static object StringToType(
-			Type type, 
-			string strType, 
-			EmptyCtorDelegate ctorFn, 
-			Dictionary<string, TypeAccessor> typeAccessorMap)
-		{
-			var index = 0;
+        internal static object StringToType(
+            Type type,
+            string strType,
+            EmptyCtorDelegate ctorFn,
+            Dictionary<string, TypeAccessor> typeAccessorMap)
+        {
+            var index = 0;
 
-			if (strType == null)
-				return null;
+            if (string.IsNullOrEmpty(strType))
+                return null;
 
-			//if (!Serializer.EatMapStartChar(strType, ref index))
-			if (strType[index++] != JsWriter.MapStartChar)
-				throw DeserializeTypeRef.CreateSerializationError(type, strType);
+            //if (!Serializer.EatMapStartChar(strType, ref index))
+            if (strType[index++] != JsWriter.MapStartChar)
+                throw DeserializeTypeRef.CreateSerializationError(type, strType);
 
-			if (strType == JsWriter.EmptyMap) return ctorFn();
+            if (strType == JsWriter.EmptyMap) return ctorFn();
 
-			object instance = null;
+            object instance = null;
 
-			var strTypeLength = strType.Length;
-			while (index < strTypeLength)
-			{
-				var propertyName = Serializer.EatMapKey(strType, ref index);
+            var strTypeLength = strType.Length;
+            while (index < strTypeLength) {
+                var propertyName = Serializer.EatMapKey(strType, ref index);
 
-				//Serializer.EatMapKeySeperator(strType, ref index);
-				index++;
+                //Serializer.EatMapKeySeperator(strType, ref index);
+                index++;
 
-				var propertyValueStr = Serializer.EatValue(strType, ref index);
-				var possibleTypeInfo = propertyValueStr != null && propertyValueStr.Length > 1 && propertyValueStr[0] == '_';
+                var propertyValueStr = Serializer.EatValue(strType, ref index);
+                var possibleTypeInfo = propertyValueStr != null && propertyValueStr.Length > 1 && propertyValueStr[0] == '_';
 
-				if (possibleTypeInfo && propertyName == JsWriter.TypeAttr)
-				{
-					var typeName = Serializer.ParseString(propertyValueStr);
-					instance = ReflectionExtensions.CreateInstance(typeName);
-					if (instance == null)
-					{
-						Tracer.Instance.WriteWarning("Could not find type: " + propertyValueStr);
-					}
-					else
-					{
-						//If __type info doesn't match, ignore it.
-						if (!type.IsInstanceOfType(instance))
-							instance = null;
-					}
+                if (possibleTypeInfo && propertyName == JsWriter.TypeAttr) {
+                    var typeName = Serializer.ParseString(propertyValueStr);
+                    instance = ReflectionExtensions.CreateInstance(typeName);
+                    if (instance == null) {
+                        Tracer.Instance.WriteWarning("Could not find type: " + propertyValueStr);
+                    }
+                    else {
+                        //If __type info doesn't match, ignore it.
+                        if (!type.IsInstanceOfType(instance))
+                            instance = null;
+                    }
 
-					//Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
-					if (index != strType.Length) index++;
+                    //Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
+                    if (index != strType.Length) index++;
 
-					continue;
-				}
+                    continue;
+                }
 
-				if (instance == null) instance = ctorFn();
+                if (instance == null) instance = ctorFn();
 
-				TypeAccessor typeAccessor;
-				typeAccessorMap.TryGetValue(propertyName, out typeAccessor);
+                TypeAccessor typeAccessor;
+                typeAccessorMap.TryGetValue(propertyName, out typeAccessor);
 
-				var propType = possibleTypeInfo ? TypeAccessor.ExtractType(Serializer, propertyValueStr) : null;
-				if (propType != null)
-				{
-					try
-					{
-						if (typeAccessor != null)
-						{
-							var parseFn = Serializer.GetParseFn(propType);
-							var propertyValue = parseFn(propertyValueStr);
-							typeAccessor.SetProperty(instance, propertyValue);
-						}
+                var propType = possibleTypeInfo ? TypeAccessor.ExtractType(Serializer, propertyValueStr) : null;
+                if (propType != null) {
+                    try {
+                        if (typeAccessor != null) {
+                            var parseFn = Serializer.GetParseFn(propType);
+                            var propertyValue = parseFn(propertyValueStr);
+                            typeAccessor.SetProperty(instance, propertyValue);
+                        }
 
-						//Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
-						if (index != strType.Length) index++;
+                        //Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
+                        if (index != strType.Length) index++;
 
-						continue;
-					}
-					catch
-					{
-						if (JsConfig.ThrowOnDeserializationError) throw;
-						else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
-					}
-				}
+                        continue;
+                    }
+                    catch {
+                        if (JsConfig.ThrowOnDeserializationError) throw;
+                        else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
+                    }
+                }
 
-				if (typeAccessor != null && typeAccessor.GetProperty != null && typeAccessor.SetProperty != null)
-				{
-					try
-					{
-						var propertyValue = typeAccessor.GetProperty(propertyValueStr);
-						typeAccessor.SetProperty(instance, propertyValue);
-					}
-					catch
-					{
-						if (JsConfig.ThrowOnDeserializationError) throw;
-						else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
-					}
-				}
+                if (typeAccessor != null && typeAccessor.GetProperty != null && typeAccessor.SetProperty != null) {
+                    try {
+                        var propertyValue = typeAccessor.GetProperty(propertyValueStr);
+                        typeAccessor.SetProperty(instance, propertyValue);
+                    }
+                    catch {
+                        if (JsConfig.ThrowOnDeserializationError) throw;
+                        else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
+                    }
+                }
 
-				//Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
-				if (index != strType.Length) index++;
-			}
+                //Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
+                if (index != strType.Length) index++;
+            }
 
-			return instance;
-		}
-	}
+            return instance;
+        }
+    }
 
-	//The same class above but JSON-specific to enable inlining in this hot class.
+    //The same class above but JSON-specific to enable inlining in this hot class.
 }

--- a/src/ServiceStack.Text/DateTimeExtensions.cs
+++ b/src/ServiceStack.Text/DateTimeExtensions.cs
@@ -15,122 +15,127 @@ using ServiceStack.Text.Common;
 
 namespace ServiceStack.Text
 {
-	/// <summary>
-	/// A fast, standards-based, serialization-issue free DateTime serailizer.
-	/// </summary>
-	public static class DateTimeExtensions
-	{
-		public const long UnixEpoch = 621355968000000000L;
-		private static readonly DateTime UnixEpochDateTimeUtc = new DateTime(UnixEpoch, DateTimeKind.Utc);
-		private static readonly DateTime UnixEpochDateTimeUnspecified = new DateTime(UnixEpoch, DateTimeKind.Unspecified);
+    /// <summary>
+    /// A fast, standards-based, serialization-issue free DateTime serailizer.
+    /// </summary>
+    public static class DateTimeExtensions
+    {
+        public const long UnixEpoch = 621355968000000000L;
+        private static readonly DateTime UnixEpochDateTimeUtc = new DateTime(UnixEpoch, DateTimeKind.Utc);
+        private static readonly DateTime UnixEpochDateTimeUnspecified = new DateTime(UnixEpoch, DateTimeKind.Unspecified);
 
-		public static long ToUnixTime(this DateTime dateTime)
-		{
-			return (dateTime.ToStableUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerSecond;
-		}
+        public static long ToUnixTime(this DateTime dateTime)
+        {
+            return (dateTime.ToStableUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerSecond;
+        }
 
-		public static DateTime FromUnixTime(this double unixTime)
-		{
-			return UnixEpochDateTimeUtc + TimeSpan.FromSeconds(unixTime);
-		}
+        public static DateTime FromUnixTime(this double unixTime)
+        {
+            return UnixEpochDateTimeUtc + TimeSpan.FromSeconds(unixTime);
+        }
 
-		public static long ToUnixTimeMs(this DateTime dateTime)
-		{
-			return (dateTime.ToStableUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerMillisecond;
-		}
+        public static long ToUnixTimeMs(this DateTime dateTime)
+        {
+            return (dateTime.ToStableUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerMillisecond;
+        }
 
-		public static DateTime FromUnixTimeMs(this double msSince1970)
-		{
-			return UnixEpochDateTimeUtc + TimeSpan.FromMilliseconds(msSince1970);
-		}
+        public static DateTime FromUnixTimeMs(this double msSince1970)
+        {
+            return UnixEpochDateTimeUtc + TimeSpan.FromMilliseconds(msSince1970);
+        }
 
-		public static DateTime FromUnixTimeMs(this long msSince1970)
-		{
-			return UnixEpochDateTimeUtc + TimeSpan.FromMilliseconds(msSince1970);
-		}
+        public static DateTime FromUnixTimeMs(this long msSince1970)
+        {
+            return UnixEpochDateTimeUtc + TimeSpan.FromMilliseconds(msSince1970);
+        }
 
-		public static DateTime FromUnixTimeMs(this long msSince1970, TimeSpan offset)
-		{
-			return UnixEpochDateTimeUnspecified + TimeSpan.FromMilliseconds(msSince1970) + offset;
-		}
+        public static DateTime FromUnixTimeMs(this long msSince1970, TimeSpan offset)
+        {
+            return UnixEpochDateTimeUnspecified + TimeSpan.FromMilliseconds(msSince1970) + offset;
+        }
 
-		public static DateTime FromUnixTimeMs(this double msSince1970, TimeSpan offset)
-		{
-			return UnixEpochDateTimeUnspecified + TimeSpan.FromMilliseconds(msSince1970) + offset;
-		}
+        public static DateTime FromUnixTimeMs(this double msSince1970, TimeSpan offset)
+        {
+            return UnixEpochDateTimeUnspecified + TimeSpan.FromMilliseconds(msSince1970) + offset;
+        }
 
-		public static DateTime FromUnixTimeMs(string msSince1970)
-		{
-			long ms;
-			if (long.TryParse(msSince1970, out ms)) return ms.FromUnixTimeMs();
+        public static DateTime FromUnixTimeMs(string msSince1970)
+        {
+            long ms;
+            if (long.TryParse(msSince1970, out ms)) return ms.FromUnixTimeMs();
 
-			// Do we really need to support fractional unix time ms time strings??
-			return double.Parse(msSince1970).FromUnixTimeMs();
-		}
+            // Do we really need to support fractional unix time ms time strings??
+            return double.Parse(msSince1970).FromUnixTimeMs();
+        }
 
-		public static DateTime FromUnixTimeMs(string msSince1970, TimeSpan offset)
-		{
-			long ms;
-			if (long.TryParse(msSince1970, out ms)) return ms.FromUnixTimeMs(offset);
+        public static DateTime FromUnixTimeMs(string msSince1970, TimeSpan offset)
+        {
+            long ms;
+            if (long.TryParse(msSince1970, out ms)) return ms.FromUnixTimeMs(offset);
 
-			// Do we really need to support fractional unix time ms time strings??
-			return double.Parse(msSince1970).FromUnixTimeMs(offset);
-		}
+            // Do we really need to support fractional unix time ms time strings??
+            return double.Parse(msSince1970).FromUnixTimeMs(offset);
+        }
 
-		public static DateTime RoundToMs(this DateTime dateTime)
-		{
-			return new DateTime((dateTime.Ticks / TimeSpan.TicksPerMillisecond) * TimeSpan.TicksPerMillisecond);
-		}
+        public static DateTime RoundToMs(this DateTime dateTime)
+        {
+            return new DateTime((dateTime.Ticks / TimeSpan.TicksPerMillisecond) * TimeSpan.TicksPerMillisecond);
+        }
 
-		public static DateTime RoundToSecond(this DateTime dateTime)
-		{
-			return new DateTime((dateTime.Ticks / TimeSpan.TicksPerSecond) * TimeSpan.TicksPerSecond);
-		}
+        public static DateTime RoundToSecond(this DateTime dateTime)
+        {
+            return new DateTime((dateTime.Ticks / TimeSpan.TicksPerSecond) * TimeSpan.TicksPerSecond);
+        }
 
-		public static string ToShortestXsdDateTimeString(this DateTime dateTime)
-		{
-			return DateTimeSerializer.ToShortestXsdDateTimeString(dateTime);
-		}
+        public static string ToShortestXsdDateTimeString(this DateTime dateTime)
+        {
+            return DateTimeSerializer.ToShortestXsdDateTimeString(dateTime);
+        }
 
-		public static DateTime FromShortestXsdDateTimeString(this string xsdDateTime)
-		{
-			return DateTimeSerializer.ParseShortestXsdDateTime(xsdDateTime);
-		}
+        public static DateTime FromShortestXsdDateTimeString(this string xsdDateTime)
+        {
+            return DateTimeSerializer.ParseShortestXsdDateTime(xsdDateTime);
+        }
 
-		public static bool IsEqualToTheSecond(this DateTime dateTime, DateTime otherDateTime)
-		{
-			return dateTime.ToStableUniversalTime().RoundToSecond().Equals(otherDateTime.ToStableUniversalTime().RoundToSecond());
-		}
+        public static bool IsEqualToTheSecond(this DateTime dateTime, DateTime otherDateTime)
+        {
+            return dateTime.ToStableUniversalTime().RoundToSecond().Equals(otherDateTime.ToStableUniversalTime().RoundToSecond());
+        }
 
-		public static string ToTimeOffsetString(this TimeSpan offset, bool includeColon = false)
-		{
-			var sign = offset < TimeSpan.Zero ? "-" : "+";
-			var hours = Math.Abs(offset.Hours);
-			var minutes = Math.Abs(offset.Minutes);
-			var separator = includeColon ? ":" : "";
-			return string.Format("{0}{1:00}{2}{3:00}", sign, hours, separator, minutes);
-		}
+        public static string ToTimeOffsetString(this TimeSpan offset, bool includeColon = false)
+        {
+            var sign = offset < TimeSpan.Zero ? "-" : "+";
+            var hours = Math.Abs(offset.Hours);
+            var minutes = Math.Abs(offset.Minutes);
+            var separator = includeColon ? ":" : "";
+            return string.Format("{0}{1:00}{2}{3:00}", sign, hours, separator, minutes);
+        }
 
-		public static TimeSpan FromTimeOffsetString(this string offsetString)
-		{
-			if (!offsetString.Contains(":"))
-				offsetString = offsetString.Insert(offsetString.Length - 2, ":");
+        public static TimeSpan FromTimeOffsetString(this string offsetString)
+        {
+            if (!offsetString.Contains(":"))
+                offsetString = offsetString.Insert(offsetString.Length - 2, ":");
 
-			offsetString = offsetString.TrimStart('+');
+            offsetString = offsetString.TrimStart('+');
 
-			return TimeSpan.Parse(offsetString);
-		}
+            return TimeSpan.Parse(offsetString);
+        }
 
-		public static DateTime ToStableUniversalTime(this DateTime dateTime)
-		{
+        public static DateTime ToStableUniversalTime(this DateTime dateTime)
+        {
 #if SILVERLIGHT
 			// Silverlight 3, 4 and 5 all work ok with DateTime.ToUniversalTime, but have no TimeZoneInfo.ConverTimeToUtc implementation.
 			return dateTime.ToUniversalTime();
 #else
-			// .Net 2.0 - 3.5 has an issue with DateTime.ToUniversalTime, but works ok with TimeZoneInfo.ConvertTimeToUtc.
-			// .Net 4.0+ does this under the hood anyway.
-			return TimeZoneInfo.ConvertTimeToUtc(dateTime);
+            // .Net 2.0 - 3.5 has an issue with DateTime.ToUniversalTime, but works ok with TimeZoneInfo.ConvertTimeToUtc.
+            // .Net 4.0+ does this under the hood anyway.
+            if (dateTime.Kind == DateTimeKind.Local)
+                return TimeZoneInfo.ConvertTimeToUtc(dateTime);
+            else
+                return dateTime;
+            //The .Net converter assumes "Unspecified" means local time, but this could cause issues during conversion (times that don't exist).
+            //A better approach is to assume UTC unless otherwise specified.
 #endif
-		}
-	}
+        }
+    }
 }

--- a/src/ServiceStack.Text/ServiceStack.Text.csproj
+++ b/src/ServiceStack.Text/ServiceStack.Text.csproj
@@ -299,6 +299,15 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>::Copy the files out to the ClientApps Build Directory
+IF EXIST "$(SolutionDir)\Builds\$(ProjectName)" rmdir /S /Q "$(SolutionDir)\Builds\$(ProjectName)"
+
+xcopy "$(TargetDir)*.*" "$(SolutionDir)\Builds\$(ProjectName)\*.*" /T /E
+xcopy "$(TargetDir)*.dll" "$(SolutionDir)\Builds\$(ProjectName)\*.dll" /E
+xcopy "$(TargetDir)*.exe" "$(SolutionDir)\Builds\$(ProjectName)\*.exe" /E
+xcopy "$(TargetDir)*.pdb" "$(SolutionDir)\Builds\$(ProjectName)\*.pdb" /E</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I ran into a couple of issues today serializing some files to disk (about 300,000 files to be exact).  After this, I made a couple of changes to the code which I believe would be helpful to others. (see attached diff).

First, in ServiceStack.Text/Common/DeserializeTypeRefJsv.cs, on line 25, it was checking to see if the input string was null.  That's good, but if the string is empty it will fail just as badly.  Therefore, I changed that to string.IsNullOrEmpty(strType)

Next, in ServiceStack.Text/DateTimeExtensions, there is a method that converts the time to universal time (ToStableUniversalTime).  Unfortunately, .NET assumes that DateTimeKind.Unspecified means local time, which is a bad assumption to make because any attempt to convert a non-utc time to utc could result in a failure if the time does not exist (for example, when switching forward into daylight savings, we lose one hour so any times within that hour do not exist).  It is much safer to assume "unspecified" means UTC and go with that.  Lines 132-137 of the new file reflect those changes.

Hope this helps! 
