### PR TITLE
I fixed an issue with serializing enumerations that had unsigned base types (uint, ulong) with the Flags attribute set.  An InvalidCastException was thrown before my change.  I added unit tests to cover the code changes.

### DIFF
--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -273,8 +273,24 @@ namespace ServiceStack.Text.Json
         public void WriteEnumFlags(TextWriter writer, object enumFlagValue)
         {
             if (enumFlagValue == null) return;
-            var intVal = (int)enumFlagValue;
-            writer.Write(intVal);
+
+            var typeCode = Type.GetTypeCode(Enum.GetUnderlyingType(enumFlagValue.GetType()));
+
+            switch (typeCode)
+            {
+                case TypeCode.UInt32:
+                    writer.Write((uint)enumFlagValue);
+                    break;
+                case TypeCode.Int64:
+                    writer.Write((long)enumFlagValue);
+                    break;
+                case TypeCode.UInt64:
+                    writer.Write((ulong)enumFlagValue);
+                    break;
+                default:
+                    writer.Write((int)enumFlagValue);
+                    break;
+            }
         }
 
         public void WriteLinqBinary(TextWriter writer, object linqBinaryValue)

--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -214,8 +214,24 @@ namespace ServiceStack.Text.Jsv
 		public void WriteEnumFlags(TextWriter writer, object enumFlagValue)
 		{
 			if (enumFlagValue == null) return;
-			var intVal = (int)enumFlagValue;
-			writer.Write(intVal);
+
+            var typeCode = Type.GetTypeCode(Enum.GetUnderlyingType(enumFlagValue.GetType()));
+
+            switch (typeCode)
+            {                
+                case TypeCode.UInt32:
+                    writer.Write((uint)enumFlagValue);
+                    break;
+                case TypeCode.Int64:
+                    writer.Write((long)enumFlagValue);
+                    break;
+                case TypeCode.UInt64:
+                    writer.Write((ulong)enumFlagValue);
+                    break;
+                default:
+                    writer.Write((int)enumFlagValue);
+                    break;
+            }
 		}
 
 		public void WriteLinqBinary(TextWriter writer, object linqBinaryValue)

--- a/tests/ServiceStack.Text.Tests/BasicStringSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/BasicStringSerializerTests.cs
@@ -36,6 +36,13 @@ namespace ServiceStack.Text.Tests
 			EnumValue2,
 		}
 
+        [Flags]
+        public enum UnsignedFlags : uint
+        {
+            EnumValue1 = 0,
+            EnumValue2 = 1,
+        }
+
 		public class TestClass
 		{
 			[Required]
@@ -150,6 +157,15 @@ namespace ServiceStack.Text.Tests
 			var stringValue = TypeSerializer.SerializeToString(enumValue);
 			Assert.That(stringValue, Is.Null);
 		}
+
+        [Test]
+        public void Can_convert_unsigned_flags_enum()
+        {
+            var enumValue = UnsignedFlags.EnumValue1;
+            var stringValue = TypeSerializer.SerializeToString(enumValue);
+            var expectedString = UnsignedFlags.EnumValue1.ToString("D");
+            Assert.That(stringValue, Is.EqualTo(expectedString));
+        }
 
 		[Test]
 		public void Can_convert_Guid()

--- a/tests/ServiceStack.Text.Tests/BclStructTests.cs
+++ b/tests/ServiceStack.Text.Tests/BclStructTests.cs
@@ -76,7 +76,5 @@ namespace ServiceStack.Text.Tests
 
             Assert.That(deserialized.Enum, Is.EqualTo(ExampleEnum.One | ExampleEnum.Four));
         }
-
-
 	}
 }

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -249,5 +249,28 @@ namespace ServiceStack.Text.Tests.JsonTests
 			Assert.That(TypeSerializer.SerializeToString(person), Is.EqualTo("{MyID:123,Name:Abc}"));
 			Assert.That(JsonSerializer.SerializeToString(person), Is.EqualTo("{\"MyID\":123,\"Name\":\"Abc\"}"));
 		}
+
+        [Flags]
+        public enum ExampleEnum : ulong
+        {
+            None = 0,
+            One = 1,
+            Two = 2,
+            Four = 4,
+            Eight = 8
+        }
+
+        [Test]
+        public void Can_serialize_unsigned_flags_enum()
+        {
+            var anon = new
+            {
+                EnumProp1 = ExampleEnum.One | ExampleEnum.Two,
+                EnumProp2 = ExampleEnum.Eight,
+            };
+
+            Assert.That(TypeSerializer.SerializeToString(anon), Is.EqualTo("{EnumProp1:3,EnumProp2:8}"));
+            Assert.That(JsonSerializer.SerializeToString(anon), Is.EqualTo("{\"EnumProp1\":3,\"EnumProp2\":8}"));
+        }
 	}
 }


### PR DESCRIPTION
...er.cs to handle unsigned Enum types.  InvalidCastException was thrown when serializing unsigned enums with the Flags attribute.
