### PR TITLE
Fix the parsing an entity that stored DateTimeOffset field was incorrect

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -78,7 +78,8 @@ namespace ServiceStack.Text.Common
 
             // for interop, do not assume format based on config
             // format: prefer TimestampOffset, DCJSCompatible
-            if (dateTimeOffsetStr.StartsWith(EscapedWcfJsonPrefix))
+            if (dateTimeOffsetStr.StartsWith(EscapedWcfJsonPrefix) ||
+                dateTimeOffsetStr.StartsWith(WcfJsonPrefix))
             {
                 return ParseWcfJsonDateOffset(dateTimeOffsetStr);
             }

--- a/tests/ServiceStack.Text.Tests/EntityWithDateTimeOffsetTests.cs
+++ b/tests/ServiceStack.Text.Tests/EntityWithDateTimeOffsetTests.cs
@@ -1,0 +1,31 @@
+﻿namespace ServiceStack.Text.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    using NUnit.Framework;
+
+    public class EntityWithDateTimeOffsetTests
+    {
+        [Test]
+        public void CanSerializableDateTimeOffsetField()
+        {
+            var model = new SampleModel() { Id = 1, Date = new DateTimeOffset(2012, 6, 27, 11, 26, 04, 524, TimeSpan.FromHours(7)) };
+
+            var s = JsonSerializer.SerializeToString(model);
+
+            var afterModel = JsonSerializer.DeserializeFromString<SampleModel>("{\"Id\":1,\"Date\":\"\\/Date(1340771164524+0700)\\/\"}");
+
+            Assert.AreEqual(model.Date, afterModel.Date);
+        }
+
+        public class SampleModel
+        {
+            public int Id { get; set; }
+
+            public DateTimeOffset Date { get; set; }
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -168,6 +168,7 @@
     <Compile Include="BclStructTests.cs" />
     <Compile Include="CyclicalDependencyTests.cs" />
     <Compile Include="DynamicModels\GoogleMapsApiTests.cs" />
+    <Compile Include="EntityWithDateTimeOffsetTests.cs" />
     <Compile Include="JsonTests\AnonymousDeserializationTests.cs" />
     <Compile Include="JsonTests\CamelCaseTests.cs" />
     <Compile Include="CsvSerializerTests.cs" />


### PR DESCRIPTION
Add the statement to check prefix of date time offset string, we should check EscapedWcfJsonPrefix or WcfJsonPrefix and Unit test for this change.
