### PR TITLE
UTC dates with ISO8601 - Serialized as Utc, deserialized as local

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -55,9 +55,15 @@ namespace ServiceStack.Text.Common
 				return DateTime.ParseExact(dateTimeStr, XsdDateTimeFormatSeconds, null,
 										   DateTimeStyles.AdjustToUniversal);
 
-			if (dateTimeStr.Length >= XsdDateTimeFormat3F.Length
-				&& dateTimeStr.Length <= XsdDateTimeFormat.Length)
-				return XmlConvert.ToDateTime(dateTimeStr, XmlDateTimeSerializationMode.Local);
+            if (dateTimeStr.Length >= XsdDateTimeFormat3F.Length
+                && dateTimeStr.Length <= XsdDateTimeFormat.Length)
+            {
+                var dateTimeType = JsConfig.DateHandler != JsonDateHandler.ISO8601
+                    ? XmlDateTimeSerializationMode.Local
+                    : XmlDateTimeSerializationMode.RoundtripKind;
+
+                return XmlConvert.ToDateTime(dateTimeStr, dateTimeType);
+            }
 
             return DateTime.Parse(dateTimeStr, null, DateTimeStyles.AssumeLocal);
         }

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -7,6 +7,19 @@ namespace ServiceStack.Text.Tests.JsonTests
 	public class JsonDateTimeTests
 	{
 		#region TimestampOffset Tests
+        [Test]
+        public void When_using_TimestampOffset_and_serializing_as_Utc_It_should_deserialize_as_Utc()
+        {
+            JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+            var initialDate = new DateTime(2012, 7, 25, 16, 17, 00, DateTimeKind.Utc);
+            var json = JsonSerializer.SerializeToString(initialDate); //"2012-07-25T16:17:00.0000000Z"
+
+            var deserializedDate = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+            Assert.AreEqual(DateTimeKind.Utc, deserializedDate.Kind);
+            Assert.AreEqual(initialDate, deserializedDate);
+        }
+
 		[Test]
 		public void Can_serialize_json_date_timestampOffset_utc()
 		{
@@ -183,6 +196,19 @@ namespace ServiceStack.Text.Tests.JsonTests
 		#endregion
 
 		#region ISO-8601 Tests
+        [Test]
+        public void When_using_ISO8601_and_serializing_as_Utc_It_should_deserialize_as_Utc()
+        {
+            JsConfig.DateHandler = JsonDateHandler.ISO8601;
+            var initialDate = new DateTime(2012, 7, 25, 16, 17, 00, DateTimeKind.Utc);
+            var json = JsonSerializer.SerializeToString(initialDate); //"2012-07-25T16:17:00.0000000Z"
+
+            var deserializedDate = JsonSerializer.DeserializeFromString<DateTime>(json);
+
+            Assert.AreEqual(DateTimeKind.Utc, deserializedDate.Kind);
+            Assert.AreEqual(initialDate, deserializedDate);
+        }
+
 		[Test]
 		public void Can_serialize_json_date_iso8601_utc()
 		{


### PR DESCRIPTION
Solves issue reported here: https://github.com/ServiceStack/ServiceStack.Text/issues/144

//Daniel
