### PR TITLE
Added quotes to json timespan output to stop parsers from breaking

### DIFF
--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -128,13 +128,13 @@ namespace ServiceStack.Text.Json
 
         public void WriteTimeSpan(TextWriter writer, object oTimeSpan)
         {
-            writer.Write(DateTimeSerializer.ToXsdTimeSpanString((TimeSpan)oTimeSpan));
+            WriteString(writer, DateTimeSerializer.ToXsdTimeSpanString((TimeSpan)oTimeSpan));
         }
 
         public void WriteNullableTimeSpan(TextWriter writer, object oTimeSpan)
         {
             if (oTimeSpan == null) return;
-            writer.Write(DateTimeSerializer.ToXsdTimeSpanString((TimeSpan?)oTimeSpan));
+            WriteString(writer, DateTimeSerializer.ToXsdTimeSpanString((TimeSpan?)oTimeSpan));
         }
 
         public void WriteGuid(TextWriter writer, object oValue)


### PR DESCRIPTION
Fixes TimeSpan output in json to be a quoted string. As a side effect snapshot pages of API output that contains TimeSpans works properly.
