### PR TITLE
Configuration for TimeSpan serialization format

### DIFF
--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -85,6 +85,8 @@ namespace ServiceStack.Text
 			}
 		}
 
+        public static JsonTimeSpanHandler TimeSpanHandler { get; set; }
+
 
 		/// <summary>
 		/// <see langword="true"/> if the <see cref="ITypeSerializer"/> is configured
@@ -253,7 +255,8 @@ namespace ServiceStack.Text
         }
 #endif
 
-	}
+
+    }
 
 #if MONOTOUCH
     [MonoTouch.Foundation.Preserve(AllMembers=true)]
@@ -428,5 +431,11 @@ namespace ServiceStack.Text
 		DCJSCompatible,
 		ISO8601
 	}
+
+    public enum JsonTimeSpanHandler
+    {
+        DurationFormat,
+        StandardFormat
+    }
 }
 

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -133,7 +133,11 @@ namespace ServiceStack.Text.Json
 
         public void WriteTimeSpan(TextWriter writer, object oTimeSpan)
         {
-            WriteRawString(writer, DateTimeSerializer.ToXsdTimeSpanString((TimeSpan)oTimeSpan));
+            var stringValue = JsConfig.TimeSpanHandler == JsonTimeSpanHandler.StandardFormat 
+                ? oTimeSpan.ToString()
+                : DateTimeSerializer.ToXsdTimeSpanString((TimeSpan)oTimeSpan);
+            WriteRawString(writer, stringValue);
+            
         }
 
         public void WriteNullableTimeSpan(TextWriter writer, object oTimeSpan)

--- a/tests/ServiceStack.Text.Tests/DateTimeOffsetAndTimeSpanTests.cs
+++ b/tests/ServiceStack.Text.Tests/DateTimeOffsetAndTimeSpanTests.cs
@@ -57,6 +57,20 @@ namespace ServiceStack.Text.Tests
             Serialize(model);
         }
 
+        [Test]
+        public void Can_serialize_TimeSpan_field_with_StandardTimeSpanFormat()
+        {
+            var period = TimeSpan.FromSeconds(70);
+
+            JsConfig.TimeSpanHandler = JsonTimeSpanHandler.StandardFormat;
+
+            var model = new SampleModel { Id = 1, TimeSpan = period };
+            var json = JsonSerializer.SerializeToString(model);
+            Assert.That(json, Is.StringContaining("\"TimeSpan\":\"00:01:10\""));
+
+            JsConfig.TimeSpanHandler = JsonTimeSpanHandler.DurationFormat;
+        }
+
         public class SampleModel
         {
             public int Id { get; set; }


### PR DESCRIPTION
Makes it possible to change the format the JsonSerializer will use through the JsConfig.TimeSpanHandler.  The default value is to keep the behaviour and by setting JsonTimeSpanHandler.StandardFormat .net ToString method of the TimeSpan will be used 
