### PR TITLE
Added failing test for JSON collections

### DIFF
--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -188,6 +188,14 @@ namespace ServiceStack.Text.Tests.JsonTests
 			Assert.That(o.Nothing, Is.EqualTo("zilch"));
 		}
 
+		[Test]
+		public void Deserialize_ignores_leading_comma()
+		{
+			var s = "[,{\"Type\":\"Programmer\",\"SampleKey\":1},{\"Type\":\"Programmer\",\"SampleKey\":2}]";
+			var o = JsonSerializer.DeserializeFromString<NullValueTester[]>(s);
+			Assert.That(o.Length, Is.EqualTo(2));
+		}
+
 		private class NullValueTester
 		{
 			public string Name


### PR DESCRIPTION
Failing tests shows a scenario where a leading comma in a JSON collection
will produce an extra object in the destination .NET collection.  I stumbled
upon it by copy/pasting some JSON and was getting unexpected results.

Maybe this is from a forgiveness factor and is by design but maybe it is
an actual bug?

I haven't verified this behavior against other JSON libraries mainly
because strong naming makes me feel stabby ;)
