### PR TITLE
Enable custom serialization on non-structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 *.lib
 *.sbr
 *.resharper.user
+*.dotCover
 obj/
 [Rr]elease*/
 _ReSharper*/

--- a/src/ServiceStack.Text/Common/JsReader.cs
+++ b/src/ServiceStack.Text/Common/JsReader.cs
@@ -13,6 +13,9 @@ namespace ServiceStack.Text.Common
 		{
 			var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
 
+			if (JsConfig<T>.DeSerializeFn != null)
+                return value => JsConfig<T>.ParseFn(Serializer.UnescapeString(value));
+
 			if (type.IsEnum)
 			{
 				return x => Enum.Parse(type, x, true);
@@ -39,9 +42,6 @@ namespace ServiceStack.Text.Common
 			var builtInMethod = DeserializeBuiltin<T>.Parse;
 			if (builtInMethod != null)
 				return value => builtInMethod(Serializer.UnescapeSafeString(value));
-
-			if (JsConfig<T>.DeSerializeFn != null)
-                return value => JsConfig<T>.ParseFn(Serializer.UnescapeString(value));
 
 			if (type.IsGenericType())
 			{

--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -243,7 +243,7 @@ namespace ServiceStack.Text.Common
             }
 
             if ((typeof(T).IsValueType && !JsConfig.TreatAsRefType(typeof(T))) ||
-                JsConfig<T>.SerializeFn != null)
+                JsConfig<T>.HasSerializeFn)
             {
                 return JsConfig<T>.SerializeFn != null
                     ? JsConfig<T>.WriteFn<TSerializer>

--- a/tests/ServiceStack.Text.Tests/NullableTypesTests.cs
+++ b/tests/ServiceStack.Text.Tests/NullableTypesTests.cs
@@ -86,6 +86,34 @@ namespace ServiceStack.Text.Tests
             Assert.That(fromJson.Items[0].tag_name, Is.EqualTo("null"));
         }
 
+        public class EntityForOverridingDeserialization
+        {
+            public int? IntValue { get; set; }
+            public bool? BoolValue { get; set; }
+            public long? LongValue { get; set; }
+            public Guid? GuidValue { get; set; }
+        }
+
+        [Test]
+		public void Test_override_DeserializeFn()
+		{
+            JsConfig<bool?>.DeSerializeFn = value => string.IsNullOrEmpty(value) ? (bool?)null : bool.Parse(value);
+			JsConfig<int?>.DeSerializeFn = value => string.IsNullOrEmpty(value) ? (int?)null : int.Parse(value);
+			JsConfig<long?>.DeSerializeFn = value => string.IsNullOrEmpty(value) ? (long?)null : long.Parse(value);
+			JsConfig<Guid?>.DeSerializeFn = value => string.IsNullOrEmpty(value) ? (Guid?)null : new Guid(value);				
+
+            try {
+                var json = "{\"intValue\":1,\"boolValue\":\"\",\"longValue\":null}";
+                var fromJson = json.FromJson<EntityForOverridingDeserialization>();
+                Assert.That(fromJson.IntValue, Is.EqualTo(1));
+                Assert.That(fromJson.BoolValue, Is.Null);
+                Assert.That(fromJson.LongValue, Is.Null);
+                Assert.That(fromJson.GuidValue, Is.Null);
+            } finally {
+                JsConfig.Reset();
+            }
+		}
+
         [Test]
         public void Can_handle_null_in_Answer()
         {
@@ -142,7 +170,6 @@ namespace ServiceStack.Text.Tests
             }
             public List<string> Strings { get; set; }
         }
-
     }
 
 }


### PR DESCRIPTION
This gives the ability to override the parse function for any type.

The use case here is to be able to deal with empty strings and null values in the same way -- of course the concept applies to any type that the user wants intimate control over deserialization of.
