### PR TITLE
Fix a bug for deserializing a dictionary into jsv

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -254,7 +254,7 @@ namespace ServiceStack.Text.Common
 
         internal static SetPropertyDelegate GetSetPropertyMethod(Type type, PropertyInfo propertyInfo)
         {
-            if (!propertyInfo.CanWrite) return null;
+            if (!propertyInfo.CanWrite || propertyInfo.GetIndexParameters().Any()) return null;
 
 #if SILVERLIGHT || MONOTOUCH || XBOX
             var setMethodInfo = propertyInfo.GetSetMethod(true);

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -74,6 +74,16 @@ namespace ServiceStack.Text.Tests.JsonTests
             Assert.That(item.DateTime, Is.Null, "datetime");
         }
 
+		[Test]
+		public void Can_parse_json_with_nulls_or_empty_string_in_nullables()
+		{
+			const string json = "{\"Int\":null,\"Boolean\":\"\"}";
+			var value = JsonSerializer.DeserializeFromString<NullableValueTypes>(json);
+
+			Assert.That(value.Int, Is.EqualTo(null));
+			Assert.That(value.Boolean, Is.EqualTo(null));
+		}
+
         [Test]
         public void Can_parse_json_with_nullable_valuetypes_that_has_no_value_specified()
         {

--- a/tests/ServiceStack.Text.Tests/JsonTests/DictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/DictionaryTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.Serialization;
+using NUnit.Framework;
+using ServiceStack.Text.Tests.DynamicModels;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+	[TestFixture]
+	public class DictionaryTests
+	{
+		public class EdgeCaseProperties : Dictionary<string, string>
+		{
+            private const string Id = "id";
+
+            [DataMember]
+            public int id
+            {
+                get
+                {
+                    int value;
+                    return (ContainsKey(Id) && int.TryParse(this[Id], out value))
+                               ? value
+                               : 0;
+                }
+                set { this[Id] = value.ToString(CultureInfo.InvariantCulture); }
+            }
+
+			public static EdgeCaseProperties Create(int i)
+			{
+			    var value = new EdgeCaseProperties { id = i };
+			    value[i.ToString()] = i.ToString();
+			    return value;
+			}
+		}
+
+		[Test]
+		public void Can_Serialize()
+		{
+			var model = EdgeCaseProperties.Create(1);
+			var s = JsonSerializer.SerializeToString(model);
+
+			Console.WriteLine(s);
+		}
+
+		[Test]
+		public void Can_Serialize_list()
+		{
+			var model = new List<EdgeCaseProperties>
+           	{
+				EdgeCaseProperties.Create(1),
+				EdgeCaseProperties.Create(2)
+           	};
+			var s = JsonSerializer.SerializeToString(model);
+
+			Console.WriteLine(s);
+		}
+
+		[Test]
+		public void Can_Serialize_map()
+		{
+			var model = new Dictionary<string, EdgeCaseProperties>
+           	{
+				{"A", EdgeCaseProperties.Create(1)},
+				{"B", EdgeCaseProperties.Create(2)},
+           	};
+			var s = JsonSerializer.SerializeToString(model);
+
+			Console.WriteLine(s);
+		}
+
+        [Test]
+        public void Can_Deserialize()
+        {
+			const string json = "{\"id\":\"1\",\"1\":\"1\"}";
+
+            var model = EdgeCaseProperties.Create(1);
+
+			var fromJson = JsonSerializer.DeserializeFromString<EdgeCaseProperties>(json);
+
+			Assert.That(fromJson, Is.EqualTo(model));
+        }
+
+        [DataContract]
+        public class Tree
+        {
+            [DataMember]
+            public string Value { get; set; }
+
+            [DataMember]
+            public List<Tree> Nodes { get; set; }
+        }
+
+        [Test]
+        public void CanSerializeAndDeserializeTree()
+        {
+            var original = new Tree
+                           {
+                               Value = "root",
+                               Nodes = new List<Tree>
+                                       {
+                                           new Tree {Value = "foo"},
+                                           new Tree {Value = "bar"},
+                                           new Tree {Value = "baz"}
+                                       }
+                           };
+            var json = original.ToJson();
+            Console.WriteLine(json);
+            var result = JsonSerializer.DeserializeFromString<Tree>(json);
+            var resultJson = result.ToJson();
+            Assert.AreEqual(json, resultJson);
+        }
+	}
+}

--- a/tests/ServiceStack.Text.Tests/JsvTests/JsvDeserializeTypeTest.cs
+++ b/tests/ServiceStack.Text.Tests/JsvTests/JsvDeserializeTypeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using ServiceStack.Text.Common;
@@ -18,6 +19,19 @@ namespace ServiceStack.Text.Tests.JsvTests
             Test test = new Test();
             setMethod.Invoke(test, "test");
             Assert.AreEqual("test", test.TestProperty);
+        }
+
+        [Test]
+        public void Get_setter_method_for_dictionary_properties()
+        {
+            var dict = new Dictionary<string, string>();
+            Type type = typeof (Dictionary<string,string>);
+            foreach (var propertyInfo in type.GetProperties()) {
+                SetPropertyDelegate setMethod = JsvDeserializeType.GetSetPropertyMethod(type, propertyInfo);
+                if (setMethod == null) continue;
+                Console.WriteLine(propertyInfo.Name);
+                setMethod.Invoke(dict, propertyInfo.Name);
+            }
         }
 
         private class Test

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="CsvStreamTests.cs" />
     <Compile Include="CsvTests\CustomHeaderTests.cs" />
     <Compile Include="JsonTests\ContractByInterfaceTests.cs" />
+    <Compile Include="JsonTests\EdgeCasePropertyTypesTests.cs" />
     <Compile Include="JsonTests\JsonDateTimeTests.cs" />
     <Compile Include="JsonTests\PolymorphicListTests.cs" />
     <Compile Include="JsonTests\ThrowOnDeserializeErrorTest.cs" />
@@ -235,6 +236,7 @@
     <Compile Include="StringSerializerTranslationTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="TypeConverterTests.cs" />
+    <Compile Include="XmlSerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/tests/ServiceStack.Text.Tests/XmlSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/XmlSerializerTests.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using Northwind.Common.DataModel;
+using NUnit.Framework;
+using ServiceStack.Text.Tests.Support;
+
+namespace ServiceStack.Text.Tests
+{
+	[TestFixture]
+	public class XmlSerializerTests
+	{
+		static XmlSerializerTests()
+		{
+			NorthwindData.LoadData(false);
+		}
+
+		public void Serialize<T>(T data)
+		{
+			//TODO: implement serializer and test properly
+			var xml = XmlSerializer.SerializeToString(data);
+			Console.WriteLine(xml);
+		}
+
+		[Test]
+		public void Can_Serialize_Movie()
+		{
+			Serialize(MoviesData.Movies[0]);
+		}
+
+		[Test]
+		public void Can_Serialize_Movies()
+		{
+			Serialize(MoviesData.Movies);
+		}
+
+		[Test]
+		public void Can_Serialize_MovieResponse_Dto()
+		{
+			Serialize(new MovieResponse { Movie = MoviesData.Movies[0] });
+		}
+
+		[Test]
+		public void serialize_Category()
+		{
+			Serialize(NorthwindData.Categories[0]);
+		}
+
+		[Test]
+		public void serialize_Categories()
+		{
+			Serialize(NorthwindData.Categories);
+		}
+
+		[Test]
+		public void serialize_Customer()
+		{
+			Serialize(NorthwindData.Customers[0]);
+		}
+
+		[Test]
+		public void serialize_Customers()
+		{
+			Serialize(NorthwindData.Customers);
+		}
+
+		[Test]
+		public void serialize_Employee()
+		{
+			Serialize(NorthwindData.Employees[0]);
+		}
+
+		[Test]
+		public void serialize_Employees()
+		{
+			Serialize(NorthwindData.Employees);
+		}
+
+		[Test]
+		public void serialize_EmployeeTerritory()
+		{
+			Serialize(NorthwindData.EmployeeTerritories[0]);
+		}
+
+		[Test]
+		public void serialize_EmployeeTerritories()
+		{
+			Serialize(NorthwindData.EmployeeTerritories);
+		}
+
+		[Test]
+		public void serialize_OrderDetail()
+		{
+			Serialize(NorthwindData.OrderDetails[0]);
+		}
+
+		[Test]
+		public void serialize_OrderDetails()
+		{
+			Serialize(NorthwindData.OrderDetails);
+		}
+
+		[Test]
+		public void serialize_Order()
+		{
+			Serialize(NorthwindData.Orders[0]);
+		}
+
+		[Test]
+		public void serialize_Orders()
+		{
+			Serialize(NorthwindData.Orders);
+		}
+
+		[Test]
+		public void serialize_Product()
+		{
+			Serialize(NorthwindData.Products[0]);
+		}
+
+		[Test]
+		public void serialize_Products()
+		{
+			Serialize(NorthwindData.Products);
+		}
+
+		[Test]
+		public void serialize_Region()
+		{
+			Serialize(NorthwindData.Regions[0]);
+		}
+
+		[Test]
+		public void serialize_Regions()
+		{
+			Serialize(NorthwindData.Regions);
+		}
+
+		[Test]
+		public void serialize_Shipper()
+		{
+			Serialize(NorthwindData.Shippers[0]);
+		}
+
+		[Test]
+		public void serialize_Shippers()
+		{
+			Serialize(NorthwindData.Shippers);
+		}
+
+		[Test]
+		public void serialize_Supplier()
+		{
+			Serialize(NorthwindData.Suppliers[0]);
+		}
+
+		[Test]
+		public void serialize_Suppliers()
+		{
+			Serialize(NorthwindData.Suppliers);
+		}
+
+		[Test]
+		public void serialize_Territory()
+		{
+			Serialize(NorthwindData.Territories[0]);
+		}
+
+		[Test]
+		public void serialize_Territories()
+		{
+			Serialize(NorthwindData.Territories);
+		}
+
+	}
+}


### PR DESCRIPTION
The issue really has to do with any type that has indexed properties, I believe.

I've added a few other tests for my own sanity, but they aren't all necessary to exercise this change.
