### PR TITLE
Extract Serialization Exception information for consuming code

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -126,6 +126,7 @@ namespace ServiceStack.Text.Common
     {
         internal ParseStringDelegate GetProperty;
         internal SetPropertyDelegate SetProperty;
+        internal Type PropertyType;
 
         public static Type ExtractType(ITypeSerializer Serializer, string strType)
         {
@@ -151,6 +152,7 @@ namespace ServiceStack.Text.Common
         {
             return new TypeAccessor
             {
+                PropertyType = propertyInfo.PropertyType,
                 GetProperty = serializer.GetParseFn(propertyInfo.PropertyType),
                 SetProperty = GetSetPropertyMethod(typeConfig, propertyInfo),
             };

--- a/src/ServiceStack.Text/Common/DeserializeTypeRef.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRef.cs
@@ -13,6 +13,21 @@ namespace ServiceStack.Text.Common
 			JsWriter.MapStartChar, type.Name, strType.Substring(0, strType.Length < 50 ? strType.Length : 50)));
 		}
 
+	    internal static SerializationException GetSerializationException(string propertyName, string propertyValueString, Type propertyType, Exception e)
+	    {
+	        var serializationException = new SerializationException(String.Format("Failed to set property '{0}' with '{1}'", propertyName, propertyValueString), e);
+	        if (propertyName != null) {
+	            serializationException.Data.Add("propertyName", propertyName);
+	        }
+	        if (propertyValueString != null) {
+	            serializationException.Data.Add("propertyValueString", propertyValueString);
+	        }
+	        if (propertyType != null) {
+	            serializationException.Data.Add("propertyType", propertyType);
+	        }
+	        return serializationException;
+	    }
+
 		/* The old Reference generic implementation
 		internal static object StringToType(
 			ITypeSerializer Serializer, 

--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
@@ -94,7 +94,7 @@ namespace ServiceStack.Text.Common
 					}
 					catch(Exception e)
 					{
-                        if (JsConfig.ThrowOnDeserializationError) throw new SerializationException(String.Format("Failed to set dynamic property '{0}' with '{1}'", propertyName, propertyValueStr), e);
+                        if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
 						else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
 					}
 				}
@@ -108,7 +108,7 @@ namespace ServiceStack.Text.Common
 					}
 					catch(Exception e)
 					{
-                        if (JsConfig.ThrowOnDeserializationError) throw new SerializationException(String.Format("Failed to set property '{0}' with '{1}'", propertyName, propertyValueStr), e);
+                        if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, typeAccessor.PropertyType, e);
                         else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
 					}
 				}
@@ -127,6 +127,5 @@ namespace ServiceStack.Text.Common
 
 			return instance;
 		}
-
 	}
 }

--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
@@ -84,7 +84,7 @@ namespace ServiceStack.Text.Common
 					}
 					catch(Exception e)
 					{
-                        if (JsConfig.ThrowOnDeserializationError) throw new SerializationException(String.Format("Failed to set dynamic property '{0}' with '{1}'", propertyName, propertyValueStr), e);
+                        if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
 						else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
 					}
 				}
@@ -98,7 +98,7 @@ namespace ServiceStack.Text.Common
 					}
 					catch(Exception e)
 					{
-                        if (JsConfig.ThrowOnDeserializationError) throw new SerializationException(String.Format("Failed to set property '{0}' with '{1}'", propertyName, propertyValueStr), e);
+                        if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
                         else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
 					}
 				}

--- a/tests/ServiceStack.Text.Tests/JsonTests/ThrowOnDeserializeErrorTest.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/ThrowOnDeserializeErrorTest.cs
@@ -32,6 +32,24 @@ namespace ServiceStack.Text.Tests.JsonTests
 		}
 
 		[Test]
+		public void Throws_on_incorrect_type_with_data_set()
+		{
+			JsConfig.Reset();
+			JsConfig.ThrowOnDeserializationError = true;
+
+            try {
+			    string json = @"{""idBad"":""abc"", ""idGood"":""2"" }";
+    		    JsonSerializer.DeserializeFromString(json, typeof(TestDto));
+                Assert.Fail("Exception should have been thrown.");
+            } catch (SerializationException ex) {
+                Assert.That(ex.Data, Is.Not.Null);
+                Assert.That(ex.Data["propertyName"], Is.EqualTo("idBad"));
+                Assert.That(ex.Data["propertyValueString"], Is.EqualTo("abc"));
+                Assert.That(ex.Data["propertyType"], Is.EqualTo(typeof(int)));
+            }
+		}
+
+		[Test]
 		public void TestDoesNotThrow()
 		{
 			JsConfig.Reset();

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -176,7 +176,7 @@
     <Compile Include="CsvStreamTests.cs" />
     <Compile Include="CsvTests\CustomHeaderTests.cs" />
     <Compile Include="JsonTests\ContractByInterfaceTests.cs" />
-    <Compile Include="JsonTests\EdgeCasePropertyTypesTests.cs" />
+    <Compile Include="JsonTests\DictionaryTests.cs" />
     <Compile Include="JsonTests\JsonDateTimeTests.cs" />
     <Compile Include="JsonTests\PolymorphicListTests.cs" />
     <Compile Include="JsonTests\ThrowOnDeserializeErrorTest.cs" />


### PR DESCRIPTION
Extracting this information out into the Data property of the exception makes it much easier for the consuming code to use it (ie to ultimately return to the user). 

In addition, returning the type of the property that's busted helps to troubleshoot the issue on the user's end. I'm not sure what (if any) performance implications there are to adding the PropertyType to the TypeAccessor though.
