### PR TITLE
Add serialization hooks for OnSerializing, OnDeserialized

### DIFF
--- a/src/ServiceStack.Text/Common/JsReader.cs
+++ b/src/ServiceStack.Text/Common/JsReader.cs
@@ -11,6 +11,16 @@ namespace ServiceStack.Text.Common
 
 		public ParseStringDelegate GetParseFn<T>()
 		{
+		    var onDeserializedFn = JsConfig<T>.OnDeserializedFn;
+            if (onDeserializedFn != null) {
+                return value => onDeserializedFn((T)GetCoreParseFn<T>()(value));
+            }
+
+		    return GetCoreParseFn<T>();
+		}
+
+	    private ParseStringDelegate GetCoreParseFn<T>()
+		{
 			var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
 
 			if (JsConfig<T>.HasDeserializeFn)

--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -237,11 +237,20 @@ namespace ServiceStack.Text.Common
 
         internal WriteObjectDelegate GetWriteFn<T>()
         {
-            if (typeof(T) == typeof(string))
-            {
+            if (typeof (T) == typeof (string)) {
                 return Serializer.WriteObjectString;
             }
 
+		    var onSerializingFn = JsConfig<T>.OnSerializingFn;
+            if (onSerializingFn != null) {
+                return (w, x) => GetCoreWriteFn<T>()(w, onSerializingFn((T)x));
+            }
+
+            return GetCoreWriteFn<T>();
+        }
+
+        private WriteObjectDelegate GetCoreWriteFn<T>()
+        {
             if ((typeof(T).IsValueType && !JsConfig.TreatAsRefType(typeof(T))) ||
                 JsConfig<T>.HasSerializeFn)
             {

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -519,6 +519,16 @@ namespace ServiceStack.Text
             }
         }
 
+        /// <summary>
+        /// Define custom serialization hook
+        /// </summary>
+        private static Func<T, T> onSerializingFn;
+        public static Func<T, T> OnSerializingFn
+        {
+            get { return onSerializingFn; }
+            set { onSerializingFn = value; }
+        }
+
 		/// <summary>
 		/// Define custom deserialization fn for BCL Structs
 		/// </summary>
@@ -534,12 +544,19 @@ namespace ServiceStack.Text
             get { return DeSerializeFn != null || RawDeserializeFn != null; }
         }
 
-		/// <summary>
+        private static Func<T, T> onDeserializedFn;
+        public static Func<T, T> OnDeserializedFn
+        {
+            get { return onDeserializedFn; }
+            set { onDeserializedFn = value; }
+        }
+
+        /// <summary>
 		/// Exclude specific properties of this type from being serialized
 		/// </summary>
 		public static string[] ExcludePropertyNames;
 
-		public static void WriteFn<TSerializer>(TextWriter writer, object obj)
+        public static void WriteFn<TSerializer>(TextWriter writer, object obj)
 		{
             if (RawSerializeFn != null) {
                 writer.Write(RawSerializeFn((T)obj));


### PR DESCRIPTION
Attempting to get a clean pull request here.

I'm not sure if this is the best approach here, so any feedback is much appreciated :)

What I'm trying to accomplish is the ability to have hooks at the time of de/serialization; what I don't want to do is take over responsibility for the object's de/serialization, but rather to affect what happens in some way.

An alternative approach would be to leverage the RawSerializeFn approach, and somehow use the standard implementation for serialize (but I couldn't find a good way to get at the standard serialize approach as a consumer).

-Andrew
