### PR TITLE
Ability to deserialize "this_property" -> "MyClass.ThisProperty" with runtime flag

### DIFF
--- a/tests/ServiceStack.Text.Tests/JsonTests/CamelCaseTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/CamelCaseTests.cs
@@ -6,7 +6,7 @@ using ServiceStack.Text.Tests.Support;
 
 namespace ServiceStack.Text.Tests.JsonTests
 {
-	[TestFixture]
+    [TestFixture]
 	public class CamelCaseTests : TestBase
 	{
 		[SetUp]

--- a/tests/ServiceStack.Text.Tests/JsonTests/PropertyConventionTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/PropertyConventionTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+    [TestFixture]
+    public class PropertyConventionTests : TestBase
+    {
+        [Test]
+        public void Does_require_exact_match_by_default()
+        {
+            Assert.That(JsConfig.PropertyConvention, Is.EqualTo(JsonPropertyConvention.ExactMatch));
+            const string bad = "{ \"total_count\":45, \"was_published\":true }";
+            const string good = "{ \"TotalCount\":45, \"WasPublished\":true }";
+            
+            var actual = JsonSerializer.DeserializeFromString<Example>(bad);
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.TotalCount, Is.EqualTo(0));
+            Assert.That(actual.WasPublished, Is.EqualTo(false));
+
+            actual = JsonSerializer.DeserializeFromString<Example>(good);
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.TotalCount, Is.EqualTo(45));
+            Assert.That(actual.WasPublished, Is.EqualTo(true));
+        }
+        
+        [Test]
+        public void Does_deserialize_from_inexact_source_when_lenient_convention_is_used()
+        {
+            JsConfig.PropertyConvention = JsonPropertyConvention.Lenient;
+            const string bad = "{ \"total_count\":45, \"was_published\":true }";
+            
+            var actual = JsonSerializer.DeserializeFromString<Example>(bad);
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.TotalCount, Is.EqualTo(45));
+            Assert.That(actual.WasPublished, Is.EqualTo(true));
+            
+            JsConfig.Reset();
+        }
+
+        public class Example
+        {
+            public int TotalCount { get; set; }
+            public bool WasPublished { get; set; }
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -187,6 +187,7 @@
     <Compile Include="JsonTests\JsonObjectTests.cs" />
     <Compile Include="JsonTests\BackingFieldTests.cs" />
     <Compile Include="JsonTests\PolymorphicListTests.cs" />
+    <Compile Include="JsonTests\PropertyConventionTests.cs" />
     <Compile Include="JsonTests\ThrowOnDeserializeErrorTest.cs" />
     <Compile Include="JsvTests\JsvDeserializeTypeTest.cs" />
     <Compile Include="MessagingTests.cs" />


### PR DESCRIPTION
For your consideration:

I use SST for HTTP client libraries, and most JSON on the planet is written lowercase_underscored. Currently SST requires exact matches such that "this_property" will not map to MyClass.ThisProperty, resulting in a null value. I know that this is worked around by declaring property names in a DataContract or using custom hooks to hijack BCL serialization, but considering how many APIs use the lowercase_underscore convention (i.e. 99% of the one's I've used), I wanted a way to do this and keep my POCO DTOs.

What I came up with is a simple intercept that switches the default TypeAccessor resolution at runtime with a static enum. Both strategies are created statically and switched during enum assignment, so there shouldn't be a performance hit for the default value unless there's some inlining situation I'm not thinking of. 
