### PR TITLE
Add support for customizing the serialized type name

### DIFF
--- a/src/ServiceStack.Text/AssemblyUtils.cs
+++ b/src/ServiceStack.Text/AssemblyUtils.cs
@@ -157,5 +157,10 @@ private static Assembly LoadAssembly(string assemblyPath)
         {
             return versionRegEx.Replace(type.AssemblyQualifiedName, "");
         }
+
+        public static string WriteType(Type type)
+        {
+            return type.ToTypeString();
+        }
     }
 }

--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-
 using ServiceStack.Text.Json;
 using ServiceStack.Text.Jsv;
 
@@ -357,7 +356,7 @@ namespace ServiceStack.Text.Common
 
         public void WriteType(TextWriter writer, object value)
         {
-            Serializer.WriteRawString(writer, ((Type)value).ToTypeString());
+            Serializer.WriteRawString(writer, JsConfig.TypeWriter((Type)value));
         }
 
     }

--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -67,7 +67,7 @@ namespace ServiceStack.Text.Common
 
 			Serializer.WriteRawString(writer, JsConfig.TypeAttr);
 			writer.Write(JsWriter.MapKeySeperator);
-			Serializer.WriteRawString(writer, typeof(T).ToTypeString());
+			Serializer.WriteRawString(writer, JsConfig.TypeWriter(typeof(T)));
 			return true;
 		}
 
@@ -77,7 +77,7 @@ namespace ServiceStack.Text.Common
 
 			Serializer.WriteRawString(writer, JsConfig.TypeAttr);
 			writer.Write(JsWriter.MapKeySeperator);
-			Serializer.WriteRawString(writer, obj.GetType().ToTypeString());
+			Serializer.WriteRawString(writer, JsConfig.TypeWriter(obj.GetType()));
 			return true;
 		}
 

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -155,6 +155,22 @@ namespace ServiceStack.Text
 			}
 		}
 
+        [ThreadStatic]
+        private static Func<Type, string> tsTypeWriter;
+        private static Func<Type, string> sTypeWriter;
+        public static Func<Type, string> TypeWriter
+        {
+            get
+            {
+                return tsTypeWriter ?? sTypeWriter ?? AssemblyUtils.WriteType;
+            }
+            set
+            {
+                tsTypeWriter = value;
+                if (sTypeWriter == null) sTypeWriter = value;
+            }
+        }
+
 		[ThreadStatic]
 		private static Func<string, Type> tsTypeFinder;
 		private static Func<string, Type> sTypeFinder;


### PR DESCRIPTION
A customization point existed for finding a type based on a string name
(JsConfig.TypeFinder), however serializing a type name was hard-coded
using the Type.ToTypeString() extension method.

This commit keeps the default behavior, but adds the ability to provide
an overriding Func<Type,string> method that generates the string
representing the type. Json.NET exposes this behavior using the
SerializationBinder class in the BCL, however only in .NET 4 does that
class support two way binding. And on the plus side, a Func is cleaner
and easier to implement.
