### PR TITLE
Add support for customizing the serialized type name

### DIFF
--- a/src/ServiceStack.Text/AssemblyUtils.cs
+++ b/src/ServiceStack.Text/AssemblyUtils.cs
@@ -157,5 +157,10 @@ private static Assembly LoadAssembly(string assemblyPath)
         {
             return versionRegEx.Replace(type.AssemblyQualifiedName, "");
         }
+
+        public static string WriteType(Type type)
+        {
+            return type.ToTypeString();
+        }
     }
 }

--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -357,7 +357,7 @@ namespace ServiceStack.Text.Common
 
         public void WriteType(TextWriter writer, object value)
         {
-            Serializer.WriteRawString(writer, ((Type)value).ToTypeString());
+            Serializer.WriteRawString(writer, JsConfig.TypeWriter((Type)value));
         }
 
     }

--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -67,7 +67,7 @@ namespace ServiceStack.Text.Common
 
 			Serializer.WriteRawString(writer, JsConfig.TypeAttr);
 			writer.Write(JsWriter.MapKeySeperator);
-			Serializer.WriteRawString(writer, typeof(T).ToTypeString());
+			Serializer.WriteRawString(writer, JsConfig.TypeWriter(typeof(T)));
 			return true;
 		}
 
@@ -77,7 +77,7 @@ namespace ServiceStack.Text.Common
 
 			Serializer.WriteRawString(writer, JsConfig.TypeAttr);
 			writer.Write(JsWriter.MapKeySeperator);
-			Serializer.WriteRawString(writer, obj.GetType().ToTypeString());
+			Serializer.WriteRawString(writer, JsConfig.TypeWriter(obj.GetType()));
 			return true;
 		}
 

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -155,6 +155,22 @@ namespace ServiceStack.Text
 			}
 		}
 
+    [ThreadStatic]
+    private static Func<Type, string> tsTypeWriter;
+    private static Func<Type, string> sTypeWriter;
+    public static Func<Type, string> TypeWriter
+    {
+      get
+      {
+        return tsTypeWriter ?? sTypeWriter ?? AssemblyUtils.WriteType;
+      }
+      set
+      {
+        tsTypeWriter = value;
+        if (sTypeWriter == null) sTypeWriter = value;
+      }
+    }
+
 		[ThreadStatic]
 		private static Func<string, Type> tsTypeFinder;
 		private static Func<string, Type> sTypeFinder;
@@ -323,6 +339,7 @@ namespace ServiceStack.Text
             tsTypeAttr = sTypeAttr = null;
             tsJsonTypeAttrInObject = sJsonTypeAttrInObject = null;
             tsJsvTypeAttrInObject = sJsvTypeAttrInObject = null;
+            tsTypeWriter = sTypeWriter = null;
             tsTypeFinder = sTypeFinder = null;
             HasSerializeFn = new HashSet<Type>();
             TreatValueAsRefTypes = new HashSet<Type> { typeof(KeyValuePair<,>) };

--- a/tests/ServiceStack.Text.Tests/JsonTests/PolymorphicListTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/PolymorphicListTests.cs
@@ -127,6 +127,26 @@ namespace ServiceStack.Text.Tests.JsonTests
 		}
 
 		[Test]
+		public void Can_serialise_polymorphic_entity_with_customised_typename()
+		{
+			try
+			{
+				JsConfig.TypeWriter = type => type.Name;
+
+				Animal dog = new Dog { Name = @"Fido", DogBark = "woof" };
+				var asText = JsonSerializer.SerializeToString(dog);
+
+				Log(asText);
+
+				Assert.That(asText,
+					Is.EqualTo(
+						"{\"__type\":\"Dog\",\"Name\":\"Fido\",\"DogBark\":\"woof\"}"));
+			} finally {
+				JsConfig.Reset();
+			}
+		}
+
+		[Test]
 		public void Can_deserialise_polymorphic_list()
 		{
 			var list =


### PR DESCRIPTION
This commit keeps the default behavior, but adds the ability to provide
an overriding Func<Type,string> method that generates the string
representing the type. Json.NET exposes this behavior using the
SerializationBinder class in the BCL, however only in .NET 4 does that
class support two way binding. And on the plus side, a Func is cleaner
and easier to implement.

Note regarding so many changes: the source files had a mix of CRLF and LF line endings, and git normalized them automatically (despite my best efforts to prevent it.)

I suggest using Github for Windows' fancy "add .gitattributes file" feature to once-and-for-all normalize all line ends to at least be consistent within each file.
In the meantime, I didn't see any way around just having these superfluous changes in this PR, sorry about that!
