### PR TITLE
use Environment.NewLine as the default row separator (rather than "\r\n")

### DIFF
--- a/src/ServiceStack.Text/CsvConfig.cs
+++ b/src/ServiceStack.Text/CsvConfig.cs
@@ -92,8 +92,6 @@ namespace ServiceStack.Text
             EscapeStrings = GetEscapeStrings();
         }
 
-		private const string DefaultRowSeparatorString = "\r\n";
-
 		[ThreadStatic]
 		private static string tsRowSeparatorString;
 		private static string sRowSeparatorString;
@@ -101,7 +99,7 @@ namespace ServiceStack.Text
 		{
 			get
 			{
-			    return tsRowSeparatorString ?? sRowSeparatorString ?? DefaultRowSeparatorString;
+			    return tsRowSeparatorString ?? sRowSeparatorString ?? Environment.NewLine;
 			}
 		    set
 			{


### PR DESCRIPTION
This is to fix the issue @desunit mentioned in https://github.com/ServiceStack/ServiceStack.Text/pull/213
