### PR TITLE
A smarter and faster StringExtensions.ToCamelCase(), with unit test

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -569,28 +569,28 @@ namespace ServiceStack.Text
         {
             if (string.IsNullOrEmpty(value)) return value;
 
-			if (value == "ID") return "id";
+            if (value == "ID") return "id";
 
-			var len = value.Length;
-			var newValue = new char[len];
-			var firstPart = true;
+            var len = value.Length;
+            var newValue = new char[len];
+            var firstPart = true;
 
-			for (var i = 0; i < len; ++i) {
-				var c0 = value[i];
-				var c1 = i < len - 1 ? value[i + 1] : 'A';
-				var c0isUpper = c0 >= 'A' && c0 <= 'Z';
-				var c1isUpper = c1 >= 'A' && c1 <= 'Z';
+            for (var i = 0; i < len; ++i) {
+                var c0 = value[i];
+                var c1 = i < len - 1 ? value[i + 1] : 'A';
+                var c0isUpper = c0 >= 'A' && c0 <= 'Z';
+                var c1isUpper = c1 >= 'A' && c1 <= 'Z';
 
-				if (firstPart && c0isUpper && (c1isUpper || i == 0))
-					c0 = (char)(c0 + LowerCaseOffset);
-				else
-					firstPart = false;
+                if (firstPart && c0isUpper && (c1isUpper || i == 0))
+                    c0 = (char)(c0 + LowerCaseOffset);
+                else
+                    firstPart = false;
 
-				newValue[i] = c0;
-			}
+                newValue[i] = c0;
+            }
 
-			return new string(newValue);
-		}
+            return new string(newValue);
+        }
 
         private static readonly TextInfo TextInfo = CultureInfo.InvariantCulture.TextInfo;
         public static string ToTitleCase(this string value)

--- a/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
+++ b/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
@@ -123,38 +123,38 @@ namespace ServiceStack.Text.Tests
             Assert.That(decoded, Is.EqualTo(text));
         }
 
-		[Test]
-		public void Can_ToCamelCase_String()
-		{
-			Assert.That("U".ToCamelCase(), Is.EqualTo("u"));
-			Assert.That("UU".ToCamelCase(), Is.EqualTo("uu"));
-			Assert.That("UUU".ToCamelCase(), Is.EqualTo("uuu"));
-			Assert.That("UUUU".ToCamelCase(), Is.EqualTo("uuuu"));
-			Assert.That("l".ToCamelCase(), Is.EqualTo("l"));
-			Assert.That("ll".ToCamelCase(), Is.EqualTo("ll"));
-			Assert.That("lll".ToCamelCase(), Is.EqualTo("lll"));
-			Assert.That("llll".ToCamelCase(), Is.EqualTo("llll"));
-			Assert.That("Ul".ToCamelCase(), Is.EqualTo("ul"));
-			Assert.That("Ull".ToCamelCase(), Is.EqualTo("ull"));
-			Assert.That("Ulll".ToCamelCase(), Is.EqualTo("ulll"));
-			Assert.That("UUl".ToCamelCase(), Is.EqualTo("uUl"));
-			Assert.That("UUll".ToCamelCase(), Is.EqualTo("uUll"));
-			Assert.That("UUUl".ToCamelCase(), Is.EqualTo("uuUl"));
-			Assert.That("lU".ToCamelCase(), Is.EqualTo("lU"));
-			Assert.That("lUl".ToCamelCase(), Is.EqualTo("lUl"));
-			Assert.That("lUll".ToCamelCase(), Is.EqualTo("lUll"));
-			Assert.That("llU".ToCamelCase(), Is.EqualTo("llU"));
-			Assert.That("llUl".ToCamelCase(), Is.EqualTo("llUl"));
-			Assert.That("lllU".ToCamelCase(), Is.EqualTo("lllU"));
-			Assert.That("llUlll".ToCamelCase(), Is.EqualTo("llUlll"));
-			Assert.That("lllUlll".ToCamelCase(), Is.EqualTo("lllUlll"));
-			Assert.That("lllUUUlll".ToCamelCase(), Is.EqualTo("lllUUUlll"));
-			Assert.That("lllUlllUlll".ToCamelCase(), Is.EqualTo("lllUlllUlll"));
-			Assert.That("".ToCamelCase(), Is.EqualTo(""));
-			Assert.That(((string)null).ToCamelCase(), Is.EqualTo((string)null));
-		}
-		
-		[Test]
+        [Test]
+        public void Can_ToCamelCase_String()
+        {
+            Assert.That("U".ToCamelCase(), Is.EqualTo("u"));
+            Assert.That("UU".ToCamelCase(), Is.EqualTo("uu"));
+            Assert.That("UUU".ToCamelCase(), Is.EqualTo("uuu"));
+            Assert.That("UUUU".ToCamelCase(), Is.EqualTo("uuuu"));
+            Assert.That("l".ToCamelCase(), Is.EqualTo("l"));
+            Assert.That("ll".ToCamelCase(), Is.EqualTo("ll"));
+            Assert.That("lll".ToCamelCase(), Is.EqualTo("lll"));
+            Assert.That("llll".ToCamelCase(), Is.EqualTo("llll"));
+            Assert.That("Ul".ToCamelCase(), Is.EqualTo("ul"));
+            Assert.That("Ull".ToCamelCase(), Is.EqualTo("ull"));
+            Assert.That("Ulll".ToCamelCase(), Is.EqualTo("ulll"));
+            Assert.That("UUl".ToCamelCase(), Is.EqualTo("uUl"));
+            Assert.That("UUll".ToCamelCase(), Is.EqualTo("uUll"));
+            Assert.That("UUUl".ToCamelCase(), Is.EqualTo("uuUl"));
+            Assert.That("lU".ToCamelCase(), Is.EqualTo("lU"));
+            Assert.That("lUl".ToCamelCase(), Is.EqualTo("lUl"));
+            Assert.That("lUll".ToCamelCase(), Is.EqualTo("lUll"));
+            Assert.That("llU".ToCamelCase(), Is.EqualTo("llU"));
+            Assert.That("llUl".ToCamelCase(), Is.EqualTo("llUl"));
+            Assert.That("lllU".ToCamelCase(), Is.EqualTo("lllU"));
+            Assert.That("llUlll".ToCamelCase(), Is.EqualTo("llUlll"));
+            Assert.That("lllUlll".ToCamelCase(), Is.EqualTo("lllUlll"));
+            Assert.That("lllUUUlll".ToCamelCase(), Is.EqualTo("lllUUUlll"));
+            Assert.That("lllUlllUlll".ToCamelCase(), Is.EqualTo("lllUlllUlll"));
+            Assert.That("".ToCamelCase(), Is.EqualTo(""));
+            Assert.That(((string)null).ToCamelCase(), Is.EqualTo((string)null));
+        }
+
+        [Test]
         public void Can_ToTitleCase_String()
         {
             var text = "Abc_def";


### PR DESCRIPTION
Original ToCamelCase:

ID ==> iD
LIBORInterestRate ==> lIBORInterestRate
IPAddress ==> iPAddress
string.Substring() and string.Concat() ==> slower

New ToCamelCase:

ID ==> id
LIBORInterestRate ==> liborInterestRate
IPAddress ==> ipAddress
new char[] and new string(char[]) ==> faster

50% to 100% time improvement when tested on Mono 3.0.1 and Mac OS 10.8.2
