### PR TITLE
Remove (mostly) harmless artifact of test/debug

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -569,8 +569,6 @@ namespace ServiceStack.Text
         {
             if (string.IsNullOrEmpty(value)) return value;
 
-            if (value == "ID") return "id";
-
             var len = value.Length;
             var newValue = new char[len];
             var firstPart = true;


### PR DESCRIPTION
Sorry, I left this line in one of my commits. No harm, it just shortcuts the (correct) return, but the comparison eats a very small amount of time on each invocation so...
