### PR TITLE
Fixed problem with serialization entities containing a polymorphic items with additional properties and fixed failing expando deserialization test

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeDynamic.cs
+++ b/src/ServiceStack.Text/Common/DeserializeDynamic.cs
@@ -59,7 +59,7 @@ namespace ServiceStack.Text.Common
                 } else if (JsonUtils.IsJsArray(elementValue)) {
                     container[mapKey] = DeserializeList<List<object>, TSerializer>.Parse(elementValue);
                 } else if (tryToParsePrimitiveTypes) {
-                    container[mapKey] = DeserializeType<TSerializer>.ParsePrimitive(elementValue);
+                    container[mapKey] = DeserializeType<TSerializer>.ParsePrimitive(elementValue) ?? Serializer.UnescapeString(elementValue);
                 } else {
                     container[mapKey] = Serializer.UnescapeString(elementValue);
                 }

--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -47,10 +47,10 @@ namespace ServiceStack.Text.Common
 			}
 			if (typeof(T).IsAbstract)
 			{
-				WriteTypeInfo = TypeInfoWriter;
-				if (!typeof(T).IsInterface)
+				WriteTypeInfo = TypeInfoWriter;	
+				if(!JsConfig.PreferInterfaces || !typeof(T).IsInterface)
 				{
-					CacheFn = WriteAbstractProperties;
+					CacheFn = WriteAbstractProperties;				
 				}
 			}
 		}

--- a/tests/ServiceStack.Text.Tests/AdhocModelTests.cs
+++ b/tests/ServiceStack.Text.Tests/AdhocModelTests.cs
@@ -139,6 +139,12 @@ namespace ServiceStack.Text.Tests
 			}
 		}
 
+		[SetUp]
+		public void SetUp()
+		{
+			JsConfig.Reset();
+		}
+
 		[Test]
 		public void Can_Deserialize_text()
 		{
@@ -292,6 +298,8 @@ namespace ServiceStack.Text.Tests
 		[Test]
 		public void Can_Serialize_Cyclical_Dependency_via_interface()
 		{
+			JsConfig.PreferInterfaces = true;
+
 			var dto = new Parent {
 				Id = 1,
 				ParentName = "Parent",
@@ -301,7 +309,7 @@ namespace ServiceStack.Text.Tests
 
 			var fromDto = Serialize(dto, includeXml: false);
 
-			var parent = (Parent)fromDto.Child.Parent;
+			var parent = (IParent)fromDto.Child.Parent;
 			Assert.That(parent.Id, Is.EqualTo(dto.Id));
 			Assert.That(parent.ParentName, Is.EqualTo(dto.ParentName));
 		}


### PR DESCRIPTION
Hello,

I have fixed issue #231 + made expando failing test green.

There is a brief description of my changes:
1. Added Can_serialize_and_deserialize_an_entity_containing_a_polymorphic_item_with_additional_properties_correctly() test:
- changed WriteType<> to use WriteAbstractProperties for interfaces if JsConfig.PreferInterfaces is not set
1. Can_deserialize_two_level_expando() test fix:
2. changed DeserializeDynamic<>.ParseDynamic() to unescape string if ParsePrimitive() return null
3. Changed Can_force_specific_TypeInfo():
4. introduced new OtherDog type that is used in test, to ensure that JsConfig<>.IncludeTypeInfo setting change would be applied before test run
5. Changed Can_Serialize_Cyclical_Dependency_via_interface() test:
6. it is valid now if JsConfig.PreferInterfaces is set to true. If this setting is not set, all properties of Parent object would be serialized, causing cyclic dependency issues
7. added SetUp() that resets JsConfig
