### PR TITLE
Fixed GetSetPropertyMethod to return delegate for derived property with private setter

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -215,6 +215,9 @@ namespace ServiceStack.Text.Common
 
         private static SetPropertyDelegate GetSetPropertyMethod(TypeConfig typeConfig, PropertyInfo propertyInfo)
         {
+            if (propertyInfo.ReflectedType != propertyInfo.DeclaringType)
+                propertyInfo = propertyInfo.DeclaringType.GetProperty(propertyInfo.Name);
+
             if (!propertyInfo.CanWrite && !typeConfig.EnableAnonymousFieldSetterses) return null;
 
             FieldInfo fieldInfo = null;


### PR DESCRIPTION
Currently GetSetPropertyMethod will return null delegate for derived properties with private setters. I've fixed it and quick-tested it using JsvSerializer<>.DeserializeFromString and JsvServiceClient.Send and it is now able to deserialize the derived properties.
