### PR TITLE
Non-interface / non-abstract-typed property of a derived class should not have type info

### DIFF
--- a/src/ServiceStack.Text/Json/JsonWriter.Generic.cs
+++ b/src/ServiceStack.Text/Json/JsonWriter.Generic.cs
@@ -99,7 +99,7 @@ namespace ServiceStack.Text.Json
 
 			var type = value.GetType();
 			var writeFn = type == typeof(object)
-				? WriteType<object, JsonTypeSerializer>.WriteEmptyType
+				? WriteType<object, JsonTypeSerializer>.WriteObjectType
 				: GetWriteFn(type);
 
 			var prevState = JsState.IsWritingDynamic;

--- a/src/ServiceStack.Text/Jsv/JsvWriter.Generic.cs
+++ b/src/ServiceStack.Text/Jsv/JsvWriter.Generic.cs
@@ -61,7 +61,7 @@ namespace ServiceStack.Text.Jsv
 			if (value == null) return;
 			var type = value.GetType();
 			var writeFn = type == typeof(object)
-                ? WriteType<object, JsvTypeSerializer>.WriteEmptyType
+                ? WriteType<object, JsvTypeSerializer>.WriteObjectType
 				: GetWriteFn(type);
 
 			var prevState = JsState.IsWritingDynamic;

--- a/tests/ServiceStack.Text.Tests/JsvTests/GeneratedJsvTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsvTests/GeneratedJsvTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ServiceStack.Text.Tests.JsvTests
+{
+    [TestFixture]
+    public class GeneratedJsvTests
+    {
+        public interface ITest
+        {}
+
+        public class TestObject : ITest
+        {
+            public TestParameter Parameter { get; set; }
+            public ITest InterfaceParameter { get; set; }
+        }
+
+        public class TestParameter : ITest
+        {
+            public string Value { get; set; }
+        }
+
+        [Test]
+        public void Interface_typed_property_in_derived_class_should_have_type_info()
+        {
+            const string expected =
+                "{__type:\"ServiceStack.Text.Tests.JsvTests.GeneratedJsvTests+TestObject, " +
+                "ServiceStack.Text.Tests\",InterfaceParameter:{__type:" +
+                "\"ServiceStack.Text.Tests.JsvTests.GeneratedJsvTests+TestParameter, " +
+                "ServiceStack.Text.Tests\",Value:Some Value}}";
+
+            ITest test = new TestObject {InterfaceParameter = new TestParameter {Value = "Some Value"}};
+            var jsv = test.ToJsv();
+            Assert.That(jsv, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Property_in_derived_class_should_not_have_type_info()
+        {
+            const string expected =
+                "{__type:\"ServiceStack.Text.Tests.JsvTests.GeneratedJsvTests+TestObject, " +
+                "ServiceStack.Text.Tests\",Parameter:{Value:Some Value}}";
+
+            ITest test = new TestObject {Parameter = new TestParameter {Value = "Some Value"}};
+            var jsv = test.ToJsv();
+            Assert.That(jsv, Is.EqualTo(expected));
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -182,6 +182,7 @@
     <Compile Include="CsvTests\CustomHeaderTests.cs" />
     <Compile Include="JsonTests\ContractByInterfaceTests.cs" />
     <Compile Include="JsonTests\DictionaryTests.cs" />
+    <Compile Include="JsvTests\GeneratedJsvTests.cs" />
     <Compile Include="JsvTests\InheritanceTests.cs" />
     <Compile Include="JsonTests\JsonArrayObjectTests.cs" />
     <Compile Include="JsonTests\JsonDateTimeTests.cs" />


### PR DESCRIPTION
### Current case

When a class is serialized as one of its base class / interface, the type info of that class will be serialized. However, in addition to that, all of its properties will have their type info serialized as well which will cause unneeded extra characters being generated.
### Result of this commit

The properties will only have their type info serialized on per required basis.
### Tests

`ServiceStack.Text.Tests.JsvTests.GeneratedJsvTests` created for this commit. All existing tests passed.
