### PR TITLE
Add missing link to JsConfigScope.cs

### DIFF
--- a/src/ServiceStack.Text.MonoTouch/ServiceStack.Text.MonoTouch/ServiceStack.Text.MonoTouch.csproj
+++ b/src/ServiceStack.Text.MonoTouch/ServiceStack.Text.MonoTouch/ServiceStack.Text.MonoTouch.csproj
@@ -264,6 +264,9 @@
     <Compile Include="..\..\ServiceStack.Text\CsvAttribute.cs">
       <Link>CsvAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\..\ServiceStack.Text\JsConfigScope.cs">
+      <Link>JsConfigScope.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\ServiceStack.Text\ServiceStack.Text.XBox360.csproj">


### PR DESCRIPTION
The file link to JsConfigScope.cs was missing in the MonoTouch project
file
