### PR TITLE
Nullable enums do not respect the [Flags] attribute

### DIFF
--- a/tests/ServiceStack.Text.Net40.Tests/ServiceStack.Text.Net40.Tests.csproj
+++ b/tests/ServiceStack.Text.Net40.Tests/ServiceStack.Text.Net40.Tests.csproj
@@ -319,7 +319,6 @@
     <Compile Include="DynamicJsonTests.cs" />
     <Compile Include="ExpandoTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="EnumTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ServiceStack.Text.Net40\ServiceStack.Text.Net40.csproj">

--- a/tests/ServiceStack.Text.Tests/EnumTests.cs
+++ b/tests/ServiceStack.Text.Tests/EnumTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 
 namespace ServiceStack.Text.Tests
@@ -43,8 +43,8 @@ namespace ServiceStack.Text.Tests
 				NullableFlagsEnum = EnumWithFlags.Two,
 				NullableNoFlagsEnum = EnumWithoutFlags.Two
 			};
-			
-			var expected = "{\"FlagsEnum\":1,\"NoFlagsEnum\":\"One\",\"NullableFlagsEnum\":2,\"NullableNoFlagsEnum\":\"Two\"}";
+
+			const string expected = "{\"FlagsEnum\":1,\"NoFlagsEnum\":\"One\",\"NullableFlagsEnum\":2,\"NullableNoFlagsEnum\":\"Two\"}";
 			var text = JsonSerializer.SerializeToString(item);
 
 			Assert.AreEqual(expected, text);

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -172,6 +172,7 @@
     <Compile Include="CyclicalDependencyTests.cs" />
     <Compile Include="DynamicModels\GoogleMapsApiTests.cs" />
     <Compile Include="DateTimeOffsetAndTimeSpanTests.cs" />
+    <Compile Include="EnumTests.cs" />
     <Compile Include="JsonTests\BasicPropertiesTests.cs" />
     <Compile Include="JsonObjectTests.cs" />
     <Compile Include="JsonTests\AnonymousDeserializationTests.cs" />


### PR DESCRIPTION
Hi,

the pull request fixes the bug that nullable enums do not respect the `[Flags]` attribute which results in the enum being serialized as an integer.

I added a unit test as well.

Cheers,
Gregor
