### PR TITLE
Fix for issue #260, Deserialize xml for Windows Phone

### DIFF
--- a/src/ServiceStack.Text/XmlSerializer.cs
+++ b/src/ServiceStack.Text/XmlSerializer.cs
@@ -36,7 +36,8 @@ namespace ServiceStack.Text
             try
             {
 #if WINDOWS_PHONE
-                using (var reader = XmlDictionaryReader.Create(xml))
+                StringReader stringReader = new StringReader(xml);
+                using (var reader = XmlDictionaryReader.Create(stringReader))
                 {
                     var serializer = new DataContractSerializer(type);
                     return serializer.ReadObject(reader);


### PR DESCRIPTION
```
    private static object Deserialize(string xml, Type type, XmlDictionaryReaderQuotas quotas)
    {
        try
        {
```
# if WINDOWS_PHONE

```
            StringReader stringReader = new StringReader(xml);
            using (var reader = XmlDictionaryReader.Create(stringReader))
            {
                var serializer = new DataContractSerializer(type);
                return serializer.ReadObject(reader);
            }
```
# else
