### PR TITLE
When deserializing a type that has a property of string array/list, where the last element is null, the last element is skipped

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeListWithElements.cs
+++ b/src/ServiceStack.Text/Common/DeserializeListWithElements.cs
@@ -83,7 +83,12 @@ namespace ServiceStack.Text.Common
                 var elementValue = Serializer.EatValue(value, ref i);
                 var listValue = Serializer.UnescapeString(elementValue);
                 to.Add(listValue);
-                Serializer.EatItemSeperatorOrMapEndChar(value, ref i);
+                if (Serializer.EatItemSeperatorOrMapEndChar(value, ref i) && i == valueLength)
+                {
+                    // If we ate a separator and we are at the end of the value, 
+                    // it means the last element is empty => add default
+                    to.Add(null);
+                }
             }
 
             return to;

--- a/tests/ServiceStack.Text.Tests/ReportedIssues.cs
+++ b/tests/ServiceStack.Text.Tests/ReportedIssues.cs
@@ -276,5 +276,44 @@ namespace ServiceStack.Text.Tests
             var deserialized = TypeSerializer.DeserializeFromString<List<int?>>(serialized);
             Assert.That(deserialized, Is.EqualTo(arrayOfInt));
         }
+        
+       [Test]
+        public void Deserialize_Correctly_When_Last_Item_Is_Null_in_String_list_prop()
+        {
+            var type = new TestMappedList() { StringListProp = new List<String> { "hello", null } };
+            var serialized = TypeSerializer.SerializeToString(type);
+            Console.WriteLine(serialized);
+            var deserialized = TypeSerializer.DeserializeFromString<TestMappedList>(serialized);
+            Assert.That(deserialized.StringListProp, Is.EqualTo(type.StringListProp));
+        }
+
+        [Test]
+        public void Deserialize_Correctly_When_Last_Item_Is_Null_in_String_array_prop()
+        {
+            var type = new TestMappedList() { StringArrayProp = new string [] { "hello", null } };
+            var serialized = TypeSerializer.SerializeToString(type);
+            Console.WriteLine(serialized);
+            var deserialized = TypeSerializer.DeserializeFromString<TestMappedList>(serialized);
+            Assert.That(deserialized.StringArrayProp, Is.EqualTo(type.StringArrayProp));
+        }
+
+        [Test]
+        public void Deserialize_Correctly_When_Last_Item_Is_Null_in_Int_array_prop()
+        {
+            var type = new TestMappedList() { IntArrayProp = new List<int?> { 1, null } };
+            var serialized = TypeSerializer.SerializeToString(type);
+            Console.WriteLine(serialized);
+            var deserialized = TypeSerializer.DeserializeFromString<TestMappedList>(serialized);
+            Assert.That(deserialized.IntArrayProp, Is.EqualTo(type.IntArrayProp));
+        }
 	}
+
+    public class TestMappedList
+    {
+        public List<String> StringListProp { get; set; }
+
+        public string[] StringArrayProp { get; set; }
+
+        public List<int?> IntArrayProp { get; set; }
+    }
 }


### PR DESCRIPTION
Found pretty much the same issue as was fixed in https://github.com/ServiceStack/ServiceStack.Text/pull/111, however this time the last null issue was happening on type properties that were list/arrays of string.

The fix is the same as pull 111, just this time its in the optimised ParseStringList(string value) method.

Added unit tests for properties that have both array and lists of String, as well as a precautionary one for int List properties (which weren't affected by this issue).
