### PR TITLE
Parse json with leading whitespace

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeDictionary.cs
+++ b/src/ServiceStack.Text/Common/DeserializeDictionary.cs
@@ -76,7 +76,7 @@ namespace ServiceStack.Text.Common
 
             var result = new JsonObject();
 
-            if (JsonTypeSerializer.IsEmptyMap(value)) return result;
+            if (JsonTypeSerializer.IsEmptyMap(value, index)) return result;
 
             var valueLength = value.Length;
             while (index < valueLength)
@@ -103,7 +103,7 @@ namespace ServiceStack.Text.Common
 
             var result = new Hashtable();
 
-            if (JsonTypeSerializer.IsEmptyMap(value)) return result;
+            if (JsonTypeSerializer.IsEmptyMap(value, index)) return result;
 
             var valueLength = value.Length;
             while (index < valueLength)
@@ -130,7 +130,7 @@ namespace ServiceStack.Text.Common
 
             var result = new Dictionary<string, string>();
 
-            if (JsonTypeSerializer.IsEmptyMap(value)) return result;
+            if (JsonTypeSerializer.IsEmptyMap(value, index)) return result;
 
             var valueLength = value.Length;
             while (index < valueLength)
@@ -167,7 +167,7 @@ namespace ServiceStack.Text.Common
                 ? new Dictionary<TKey, TValue>()
                 : (IDictionary<TKey, TValue>)createMapType.CreateInstance();
 
-            if (JsonTypeSerializer.IsEmptyMap(value)) return to;
+            if (JsonTypeSerializer.IsEmptyMap(value, index)) return to;
 
             var valueLength = value.Length;
             while (index < valueLength)

--- a/src/ServiceStack.Text/Common/DeserializeKeyValuePair.cs
+++ b/src/ServiceStack.Text/Common/DeserializeKeyValuePair.cs
@@ -53,9 +53,9 @@ namespace ServiceStack.Text.Common
         {
             if (value == null) return default(KeyValuePair<TKey, TValue>);
 
-            var index = 1;
+            var index = VerifyAndGetStartIndex(value, createMapType);
 
-            if (JsonTypeSerializer.IsEmptyMap(value)) return new KeyValuePair<TKey, TValue>();
+            if (JsonTypeSerializer.IsEmptyMap(value, index)) return new KeyValuePair<TKey, TValue>();
             var keyValue = default(TKey);
             var valueValue = default(TValue);
 
@@ -76,6 +76,18 @@ namespace ServiceStack.Text.Common
             }
 
             return new KeyValuePair<TKey, TValue>(keyValue, valueValue);
+        }
+
+        private static int VerifyAndGetStartIndex(string value, Type createMapType)
+        {
+            var index = 0;
+            if (!Serializer.EatMapStartChar(value, ref index))
+            {
+                //Don't throw ex because some KeyValueDataContractDeserializer don't have '{}'
+                Tracer.Instance.WriteDebug("WARN: Map definitions should start with a '{0}', expecting serialized type '{1}', got string starting with: {2}",
+                                           JsWriter.MapStartChar, createMapType != null ? createMapType.Name : "Dictionary<,>", value.Substring(0, value.Length < 50 ? value.Length : 50));
+            }
+            return index;
         }
 
         private static Dictionary<string, ParseKeyValuePairDelegate> ParseDelegateCache

--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
@@ -66,7 +66,7 @@ namespace ServiceStack.Text.Common
             if (strType[index++] != JsWriter.MapStartChar)
                 throw DeserializeTypeRef.CreateSerializationError(type, strType);
 
-            if (JsonTypeSerializer.IsEmptyMap(strType)) return ctorFn();
+            if (JsonTypeSerializer.IsEmptyMap(strType, index)) return ctorFn();
 
             object instance = null;
 

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -322,9 +322,8 @@ namespace ServiceStack.Text.Json
             return string.IsNullOrEmpty(value) ? value : ParseRawString(value);
         }
 
-        internal static bool IsEmptyMap(string value)
+        internal static bool IsEmptyMap(string value, int i = 1)
         {
-            var i = 1;
             for (; i < value.Length; i++) { var c = value[i]; if (c >= WhiteSpaceFlags.Length || !WhiteSpaceFlags[c]) break; } //Whitespace inline
             if (value.Length == i) return true;
             return value[i++] == JsWriter.MapEndChar;

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NUnit.Framework;
@@ -361,6 +362,111 @@ namespace ServiceStack.Text.Tests.JsonTests
         {
             var o = JsonSerializer.DeserializeFromString("", typeof(JsonPrimitives));
             Assert.IsNull(o);
-        }    
+        }
+
+        [Test]
+        public void Can_parse_empty_string_dictionary_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Dictionary<string, string>>();
+            Assert.That(serializer.DeserializeFromString(" {}"), Is.Empty);
+        }
+
+        [Test]
+        public void Can_parse_nonempty_string_dictionary_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Dictionary<string, string>>();
+            var dictionary = serializer.DeserializeFromString(" {\"A\":\"N\",\"B\":\"O\"}");
+            Assert.That(dictionary.Count, Is.EqualTo(2));
+            Assert.That(dictionary["A"], Is.EqualTo("N"));
+            Assert.That(dictionary["B"], Is.EqualTo("O"));
+        }
+
+        [Test]
+        public void Can_parse_empty_dictionary_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Dictionary<int, double>>();
+            Assert.That(serializer.DeserializeFromString(" {}"), Is.Empty);
+        }
+
+        [Test]
+        public void Can_parse_nonempty_dictionary_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Dictionary<int, double>>();
+            var dictionary = serializer.DeserializeFromString(" {\"1\":2.5,\"2\":5}");
+            Assert.That(dictionary.Count, Is.EqualTo(2));
+            Assert.That(dictionary[1], Is.EqualTo(2.5));
+            Assert.That(dictionary[2], Is.EqualTo(5.0));
+        }
+
+        [Test]
+        public void Can_parse_empty_hashtable_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Hashtable>();
+            Assert.That(serializer.DeserializeFromString(" {}"), Is.Empty);
+        }
+
+        [Test]
+        public void Can_parse_nonempty_hashtable_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Hashtable>();
+            var hashtable = serializer.DeserializeFromString(" {\"A\":1,\"B\":2}");
+            Assert.That(hashtable.Count, Is.EqualTo(2));
+            Assert.That(hashtable["A"].ToString(), Is.EqualTo(1.ToString()));
+            Assert.That(hashtable["B"].ToString(), Is.EqualTo(2.ToString()));
+        }
+
+        [Test]
+        public void Can_parse_empty_json_object_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<JsonObject>();
+            Assert.That(serializer.DeserializeFromString(" {}"), Is.Empty);
+        }
+
+        [Test]
+        public void Can_parse_nonempty_json_object_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<JsonObject>();
+            var jsonObject = serializer.DeserializeFromString(" {\"foo\":\"bar\"}");
+            Assert.That(jsonObject, Is.Not.Empty);
+            Assert.That(jsonObject["foo"], Is.EqualTo("bar"));
+        }
+
+        [Test]
+        public void Can_parse_empty_key_value_pair_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<KeyValuePair<string, string>>();
+            Assert.That(serializer.DeserializeFromString(" {}"), Is.EqualTo(default(KeyValuePair<string, string>)));
+        }
+
+        [Test]
+        public void Can_parse_nonempty_key_value_pair_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<KeyValuePair<string, string>>();
+            var keyValuePair = serializer.DeserializeFromString(" {\"Key\":\"foo\"\"Value\":\"bar\"}");
+            Assert.That(keyValuePair, Is.EqualTo(new KeyValuePair<string, string>("foo", "bar")));
+        }
+
+        [Test]
+        public void Can_parse_empty_object_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Foo>();
+            var foo = serializer.DeserializeFromString(" {}");
+            Assert.That(foo, Is.Not.Null);
+            Assert.That(foo.Bar, Is.Null);
+        }
+
+        [Test]
+        public void Can_parse_nonempty_object_with_leading_whitespace()
+        {
+            var serializer = new JsonSerializer<Foo>();
+            var foo = serializer.DeserializeFromString(" {\"Bar\":\"baz\"}");
+            Assert.That(foo, Is.Not.Null);
+            Assert.That(foo.Bar, Is.EqualTo("baz"));
+        }
+
+        public class Foo
+        {
+            public string Bar { get; set; }
+        }
 	}
 }


### PR DESCRIPTION
Leading whitespace in a json string for an empty object (e.g. `" {}"`) is
only successfully parsed for user-defined classes - it fails in one way
or another for: `Dictionary<string, string>`, `Dictionary<TKey, TValue>`
(any other type of dictionary), `Hashtable`, `JsonObject`, or
`KeyValuePair<TKey, TValue>`. Furthermore, for a user-defined class, the
shortcutting check for an empty object is not invoked if there is any
leading whitespace.

Added index parameter for JsonTypeSerializer.IsEmptyMap. Most callers of
this method were already calculating the index if the first
non-whitespace character, but IsEmptyMap was not taking this index value
into account - it was returning false when it should have been returning
true.

NOTE: JSV is not affected by this change, only JSON.
