### PR TITLE
Support property name conventions in per-type JsConfig<T>

### DIFF
--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -188,9 +188,9 @@ namespace ServiceStack.Text.Common
             {
                 get
                 {
-                    return (JsConfig.EmitCamelCaseNames)
+                    return (JsConfig<T>.EmitCamelCaseNames || JsConfig.EmitCamelCaseNames)
                         ? propertyNameCLSFriendly
-                        : (JsConfig.EmitLowercaseUnderscoreNames)
+                        : (JsConfig<T>.EmitLowercaseUnderscoreNames || JsConfig.EmitLowercaseUnderscoreNames)
                             ? propertyNameLowercaseUnderscore
                             : propertyName;
                 }

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -716,6 +716,8 @@ namespace ServiceStack.Text
         /// </summary>
         public static bool EmitCamelCaseNames = false;
 
+        public static bool EmitLowercaseUnderscoreNames = false;
+
         /// <summary>
         /// Define custom serialization fn for BCL Structs
         /// </summary>

--- a/tests/ServiceStack.Text.Tests/StructTests.cs
+++ b/tests/ServiceStack.Text.Tests/StructTests.cs
@@ -116,7 +116,7 @@ namespace ServiceStack.Text.Tests
 		[Test]
 		public void Test_enum_overloads()
 		{
-			JsConfig.EmitCamelCaseNames = true;
+			JsConfig<Person>.EmitCamelCaseNames = true;
 			JsConfig.IncludeNullValues = true;
 			JsConfig<PersonStatus>.SerializeFn = text => text.ToString().ToCamelCase();
 


### PR DESCRIPTION
I needed to customise JSON property names on a per-type basis, but the `EmitCamelCaseNames` property on `JsConfig<T>` was being ignored. I'm specifically interested in `EmitLowercaseUnderscoreNames` so also added this.

I have no idea if this fix is correct, or how to write a specific test for it, but it works and doesn't break anything. If it can be improved, please let me know.
