### PR TITLE
Object types not parsed with TryToParsePrimitiveTypeValues option turned on

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeDictionary.cs
+++ b/src/ServiceStack.Text/Common/DeserializeDictionary.cs
@@ -206,7 +206,9 @@ namespace ServiceStack.Text.Common
                     if (tryToParseItemsAsPrimitiveTypes && elementStartIndex < valueLength)
                     {
                         Serializer.EatWhitespace(value, ref elementStartIndex);
-                        to[mapKey] = (TValue)DeserializeType<TSerializer>.ParsePrimitive(elementValue, value[elementStartIndex]);
+                        to[mapKey] = DeserializeType<TSerializer>.ExtractType(elementValue) != null
+                            ? (TValue)parseValueFn(elementValue)
+                            : (TValue)DeserializeType<TSerializer>.ParsePrimitive(elementValue, value[elementStartIndex]);
                     }
                     else
                     {


### PR DESCRIPTION
When setting `JsConfig.TryToParsePrimitiveTypeValues = true`, strong-typed objects in dictionaries are left as the serialized string on deserialization. 
