### PR TITLE
Missing Using in .NET 4 build

### DIFF
--- a/src/ServiceStack.Text/DynamicJson.cs
+++ b/src/ServiceStack.Text/DynamicJson.cs
@@ -1,4 +1,5 @@
 ﻿#if NET40
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;


### PR DESCRIPTION
.NET 4 version didn't seem to compile without this, was missing from da942992 commit, fix for #251
