### PR TITLE
NET40 project didn't define constant for release builds

### DIFF
--- a/src/ServiceStack.Text.Net40/ServiceStack.Text.Net40.csproj
+++ b/src/ServiceStack.Text.Net40/ServiceStack.Text.Net40.csproj
@@ -26,7 +26,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
Just a minor change, needed a release build for use in a project with the `DynamicJson` class but didn't exist in release builds.
