### PR TITLE
StringExtensions.ToLowercaseUnderscore does not use InvariantCulture

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -662,7 +662,7 @@ namespace ServiceStack.Text
                 else
                 {
                     sb.Append("_");
-                    sb.Append(Char.ToLower(t));
+                    sb.Append(Char.ToLower(t, CultureInfo.InvariantCulture));
                 }
             }
             return sb.ToString();


### PR DESCRIPTION
LowercaseUnderscoreTests.Does_serialize_To_lowercase_underscore fails
with Turkish culture.
