### PR TITLE
Support different value types in IDictionary collections

### DIFF
--- a/src/ServiceStack.Text/Common/WriteDictionary.cs
+++ b/src/ServiceStack.Text/Common/WriteDictionary.cs
@@ -117,9 +117,6 @@ namespace ServiceStack.Text.Common
                     encodeMapKey = Serializer.GetTypeInfo(keyType).EncodeMapKey;
                 }
 
-                if (writeValueFn == null)
-                    writeValueFn = Serializer.GetWriteFn(dictionaryValue.GetType());
-
                 JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);
 
                 JsState.WritingKeyCount++;
@@ -147,6 +144,7 @@ namespace ServiceStack.Text.Common
                 }
                 else
                 {
+                    writeValueFn = Serializer.GetWriteFn(dictionaryValue.GetType());
                     JsState.IsWritingValue = true;
                     writeValueFn(writer, dictionaryValue);
                     JsState.IsWritingValue = false;


### PR DESCRIPTION
When we JSON serialize Hashtable that has values of different types, values are serialized incorrectly or InvalidCastException is thrown.

Case 1:

``` C#
    Hashtable htable = new Hashtable();
    htable.Add("1-Text", "Hello");
    htable.Add("2-Date", DateTime.Now);
    Console.WriteLine(htable.ToJson());
```

Result:

```
{"1-Text":"Hello","2-Date":"04/10/2013 3:10:37 PM"}
```

Date is not serialized as date. It should be "\/Date(1365592617200+0400)\/"

Case 2 (Please note: Date is a first key in collection):

``` C#
    Hashtable htable = new Hashtable();
    htable.Add("1-Date", DateTime.Now);
    htable.Add("2-Text", "Hello");
    Console.WriteLine(htable.ToJson());
```

Result:

```
System.InvalidCastException: Specified cast is not valid.
```
