### PR TITLE
Fixed SL5 compilation

### DIFF
--- a/src/ServiceStack.Text.SL5/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Text.SL5/Properties/AssemblyInfo.cs
@@ -21,15 +21,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b058736d-b210-47e1-b16f-ba72d92e7c4e")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("3.9.43.0")]

--- a/src/ServiceStack.Text.SL5/ServiceStack.Text.SL5.csproj
+++ b/src/ServiceStack.Text.SL5/ServiceStack.Text.SL5.csproj
@@ -168,6 +168,9 @@
     <Compile Include="..\ServiceStack.Text\JsConfig.cs">
       <Link>JsConfig.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.Text\JsConfigScope.cs">
+      <Link>JsConfigScope.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.Text\JsonObject.cs">
       <Link>JsonObject.cs</Link>
     </Compile>
@@ -284,7 +287,7 @@
       <FlavorProperties GUID="{A1591282-1198-4647-A2B1-27E5FF5F6F3B}">
         <SilverlightProjectProperties />
       </FlavorProperties>
-      <UserProperties ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" ProjectLinkReference="579b3fdb-cdad-44e1-8417-885c38e49a0e" />
+      <UserProperties ProjectLinkReference="579b3fdb-cdad-44e1-8417-885c38e49a0e" ProjectLinkerExcludeFilter="\\?desktop(\\.*)?$;\\?silverlight(\\.*)?$;\.desktop;\.silverlight;\.xaml;^service references(\\.*)?$;\.clientconfig;^web references(\\.*)?$" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/ServiceStack.Text/JsonSerializer.cs
+++ b/src/ServiceStack.Text/JsonSerializer.cs
@@ -167,7 +167,7 @@ namespace ServiceStack.Text
 			}
 		}
 
-#if !WINDOWS_PHONE
+#if !WINDOWS_PHONE && !SILVERLIGHT
 		public static T DeserializeResponse<T>(WebRequest webRequest)
 		{
 #if NETFX_CORE


### PR DESCRIPTION
Aligned version number with the rest of ServiceStack and added missing file
links and excluded few blocks that can't compile in Silverlight 'mode'.
