### PR TITLE
JsonSerializer.SerializeToString throws OutOfRangeException

### DIFF
--- a/src/ServiceStack.Text/DateTimeExtensions.cs
+++ b/src/ServiceStack.Text/DateTimeExtensions.cs
@@ -46,7 +46,7 @@ namespace ServiceStack.Text
             var dtUtc = dateTime;
             if (dateTime.Kind != DateTimeKind.Utc)
             {
-                dtUtc = dateTime.Kind == DateTimeKind.Unspecified
+                dtUtc = dateTime.Kind == DateTimeKind.Unspecified && dateTime > DateTime.MinValue
                     ? DateTime.SpecifyKind(dateTime.Subtract(LocalTimeZone.GetUtcOffset(dateTime)), DateTimeKind.Utc)
                     : dateTime.ToStableUniversalTime();
             }


### PR DESCRIPTION
JsonSerializer.SerializeToString throws OutOfRangeException when serializing object containing DateTime field with value of DateTime.MinValue (0001-01-01 0:00) and current TimeZone offset is positive.
