### PR TITLE
Fixed SL5 build, but also other builds (please see comment below). Should be painless to integrate this. Also, please let me know next time you want to push a new NuGet build so that I can update SL5 binaries, thanks!

### DIFF
--- a/src/ServiceStack.Text.SL5/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.Text.SL5/Properties/AssemblyInfo.cs
@@ -21,4 +21,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b058736d-b210-47e1-b16f-ba72d92e7c4e")]
-[assembly: AssemblyVersion("3.9.44.0")]
+[assembly: AssemblyVersion("3.9.48.0")]

--- a/src/ServiceStack.Text/DateTimeExtensions.cs
+++ b/src/ServiceStack.Text/DateTimeExtensions.cs
@@ -41,7 +41,7 @@ namespace ServiceStack.Text
             return (dateTime.ToStableUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerMillisecond;
         }
 
-        private static TimeZone LocalTimeZone = TimeZone.CurrentTimeZone;
+        private static TimeZoneInfo LocalTimeZone = TimeZoneInfo.Local;
         public static long ToUnixTimeMs(this DateTime dateTime)
         {
             var dtUtc = dateTime;


### PR DESCRIPTION
Microsoft recommends to use TimeZoneInfo instead of TimeZone for all recent
versions (starting from 3.5) of the .NET, plus this is the only class
available in non-mainstream flavors of .NET (like Silverlight),
so why not use it.
Also update the assembly version of the SL5 build of ServiceStack.Text.
