### PR TITLE
Handle DataContract annotation in enum types

### DIFF
--- a/src/ServiceStack.Text/Common/ITypeSerializer.cs
+++ b/src/ServiceStack.Text/Common/ITypeSerializer.cs
@@ -42,6 +42,7 @@ namespace ServiceStack.Text.Common
         void WriteDouble(TextWriter writer, object doubleValue);
         void WriteDecimal(TextWriter writer, object decimalValue);
         void WriteEnum(TextWriter writer, object enumValue);
+        WriteObjectDelegate EnumDataContractDelegate(Type type);
         void WriteEnumFlags(TextWriter writer, object enumFlagValue);
         void WriteLinqBinary(TextWriter writer, object linqBinaryValue);
 

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -299,6 +299,18 @@ namespace ServiceStack.Text.Json
 			JsWriter.WriteEnumFlags(writer, enumFlagValue);
         }
 
+        public WriteObjectDelegate EnumDataContractDelegate(Type type)
+        {
+            var mapping = JsWriter.CreateEnumDataContractMap(type);
+            return (writer, enumValue) =>
+            {
+                if (enumValue == null) return;
+                else if (!mapping.ContainsKey(enumValue)) throw new ArgumentException("Illegal enum value");
+                WriteRawString(writer, mapping[enumValue]);
+            };
+        }
+
+
         public void WriteLinqBinary(TextWriter writer, object linqBinaryValue)
         {
 #if !MONOTOUCH && !SILVERLIGHT && !XBOX  && !ANDROID

--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -227,6 +227,17 @@ namespace ServiceStack.Text.Jsv
 				writer.Write(enumValue.ToString());
 		}
 
+        public WriteObjectDelegate EnumDataContractDelegate(Type type)
+        {
+            var mapping = JsWriter.CreateEnumDataContractMap(type);
+            return (writer, enumValue) =>
+            {
+                if (enumValue == null) return;
+                else if (!mapping.ContainsKey(enumValue)) throw new ArgumentException("Illegal enum value");
+                writer.Write(mapping[enumValue]);
+            };
+        }
+
         public void WriteEnumFlags(TextWriter writer, object enumFlagValue)
         {
 			JsWriter.WriteEnumFlags(writer, enumFlagValue);


### PR DESCRIPTION
When an enum type has a [DataContract] annotation, use the specified
values from the EnumMember annotations when reading/writing Json and
JSV.
See  #337.

You might want the helper methods structured differently.
You might also want different exception behaviour. I aimed for throwing when the Xml serializer throws, but I don't throw the same exceptions.
