### PR TITLE
Fix for Issue #335 (double quotes for string enums to json)

### DIFF
--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -288,10 +288,10 @@ namespace ServiceStack.Text.Json
         public void WriteEnum(TextWriter writer, object enumValue)
         {
             if (enumValue == null) return;
-			if (JsConfig.TreatEnumAsInteger)
-				JsWriter.WriteEnumFlags(writer, enumValue);
-			else
-				WriteRawString(writer, enumValue.ToString());
+            if (JsConfig.TreatEnumAsInteger)
+                JsWriter.WriteEnumFlags(writer, enumValue);
+            else
+                writer.Write(enumValue);
         }
 
         public void WriteEnumFlags(TextWriter writer, object enumFlagValue)

--- a/tests/ServiceStack.Text.Tests/AdhocModelTests.cs
+++ b/tests/ServiceStack.Text.Tests/AdhocModelTests.cs
@@ -526,6 +526,37 @@ namespace ServiceStack.Text.Tests
             Assert.That(json, Is.EqualTo("[\"Enum1\",\"Enum2\",\"Enum3\"]"));
         }
 
+        public class DictionaryEnumType
+        {
+            public Dictionary<EnumValues, Test> DictEnumType { get; set; }
+        }
+
+        [Test]
+        public void Can_Serialize_Dictionary_With_Enums()
+        {
+
+            Dictionary<EnumValues, Test> dictEnumType =
+                new Dictionary<EnumValues, Test> 
+                {
+                    {
+                        EnumValues.Enum1, new Test { Val = "A Value" }
+                    }
+                };
+
+            var item = new DictionaryEnumType
+            {
+                DictEnumType = dictEnumType
+            };
+            const string expected = "{\"DictEnumType\":{\"Enum1\":{\"Val\":\"A Value\"}}}";
+
+            var jsonItem = JsonSerializer.SerializeToString(item);
+            //Log(jsonItem);
+            Assert.That(jsonItem, Is.EqualTo(expected));
+
+            var deserializedItem = JsonSerializer.DeserializeFromString<DictionaryEnumType>(jsonItem);
+            Assert.That(deserializedItem, Is.TypeOf<DictionaryEnumType>());
+        }
+
         [Test]
         public void Can_Serialize_Array_of_chars()
         {


### PR DESCRIPTION
Added test in AdhocModelTests.cs and fix in JsonTypeSerializer.cs
