### PR TITLE
TryToParsePrimitiveTypeValues numeric values default to decimal

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -161,19 +161,19 @@ namespace ServiceStack.Text.Common
             decimal decimalValue;
             if (decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out decimalValue))
             {
+	            if (!JsConfig.TryToParseNumericType)
+		            return decimalValue;
+
                 if (decimalValue == decimal.Truncate(decimalValue))
-                {
-                    if (decimalValue <= ulong.MaxValue && decimalValue >= 0) return (ulong)decimalValue;
-                    if (decimalValue <= long.MaxValue && decimalValue >= long.MinValue)
-                    {
-                        var longValue = (long)decimalValue;
-                        if (longValue <= sbyte.MaxValue && longValue >= sbyte.MinValue) return (sbyte)longValue;
-                        if (longValue <= byte.MaxValue && longValue >= byte.MinValue) return (byte)longValue;
-                        if (longValue <= short.MaxValue && longValue >= short.MinValue) return (short)longValue;
-                        if (longValue <= ushort.MaxValue && longValue >= ushort.MinValue) return (ushort)longValue;
-                        if (longValue <= int.MaxValue && longValue >= int.MinValue) return (int)longValue;
-                        if (longValue <= uint.MaxValue && longValue >= uint.MinValue) return (uint)longValue;
-                    }
+				{
+					if (decimalValue <= byte.MaxValue && decimalValue >= byte.MinValue) return (byte)decimalValue;
+					if (decimalValue <= sbyte.MaxValue && decimalValue >= sbyte.MinValue) return (sbyte)decimalValue;
+					if (decimalValue <= Int16.MaxValue && decimalValue >= Int16.MinValue) return (Int16)decimalValue;
+					if (decimalValue <= UInt16.MaxValue && decimalValue >= UInt16.MinValue) return (UInt16)decimalValue;
+					if (decimalValue <= Int32.MaxValue && decimalValue >= Int32.MinValue) return (Int32)decimalValue;
+					if (decimalValue <= UInt32.MaxValue && decimalValue >= UInt32.MinValue) return (UInt32)decimalValue;
+					if (decimalValue <= Int64.MaxValue && decimalValue >= Int64.MinValue) return (Int64)decimalValue;
+					if (decimalValue <= UInt64.MaxValue && decimalValue >= UInt64.MinValue) return (UInt64)decimalValue;
                 }
                 return decimalValue;
             }

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -31,6 +31,7 @@ namespace ServiceStack.Text
         public static JsConfigScope With(
             bool? convertObjectTypesIntoStringDictionary = null,
             bool? tryToParsePrimitiveTypeValues = null,
+			bool? tryToParseNumericType = null,
             bool? includeNullValues = null,
             bool? excludeTypeInfo = null,
             bool? includeTypeInfo = null,
@@ -54,6 +55,7 @@ namespace ServiceStack.Text
             return new JsConfigScope {
                 ConvertObjectTypesIntoStringDictionary = convertObjectTypesIntoStringDictionary ?? sConvertObjectTypesIntoStringDictionary,
                 TryToParsePrimitiveTypeValues = tryToParsePrimitiveTypeValues ?? sTryToParsePrimitiveTypeValues,
+                TryToParseNumericType = tryToParseNumericType ?? sTryToParseNumericType,
                 IncludeNullValues = includeNullValues ?? sIncludeNullValues,
                 ExcludeTypeInfo = excludeTypeInfo ?? sExcludeTypeInfo,
                 IncludeTypeInfo = includeTypeInfo ?? sIncludeTypeInfo,
@@ -105,6 +107,21 @@ namespace ServiceStack.Text
                 if (!sTryToParsePrimitiveTypeValues.HasValue) sTryToParsePrimitiveTypeValues = value;
             }
         }
+
+		private static bool? sTryToParseNumericType;
+		public static bool TryToParseNumericType
+		{
+			get
+			{
+				return (JsConfigScope.Current != null ? JsConfigScope.Current.TryToParseNumericType : null)
+					?? sTryToParseNumericType
+					?? false;
+			}
+			set
+			{
+				if (!sTryToParseNumericType.HasValue) sTryToParseNumericType = value;
+			}
+		}
 
         private static bool? sIncludeNullValues;
         public static bool IncludeNullValues
@@ -506,7 +523,8 @@ namespace ServiceStack.Text
             }
         }
 
-        public static void Reset()
+
+	    public static void Reset()
         {
             foreach (var rawSerializeType in HasSerializeFn.ToArray())
             {
@@ -515,6 +533,7 @@ namespace ServiceStack.Text
 
             sModelFactory = ReflectionExtensions.GetConstructorMethodToCache;
             sTryToParsePrimitiveTypeValues = null;
+		    sTryToParseNumericType = null;
             sConvertObjectTypesIntoStringDictionary = null;
             sIncludeNullValues = null;
             sExcludeTypeInfo = null;

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -57,6 +57,7 @@ namespace ServiceStack.Text
 
         public bool? ConvertObjectTypesIntoStringDictionary { get; set; }
         public bool? TryToParsePrimitiveTypeValues { get; set; }
+		public bool? TryToParseNumericType { get; set; }
         public bool? IncludeNullValues { get; set; }
         public bool? TreatEnumAsInteger { get; set; }
         public bool? ExcludeTypeInfo { get; set; }


### PR DESCRIPTION
Changed default behaviour of TryToParsePrimitiveTypeValues to always parse numeric types as either decimal, float or double.

This IMO is the safest choice as you shouldn't get any issues down the line working with decimals.
It is also the what I would expect from json.
Added config value TryToParseNumericType to allow the 'best' type to come back as per expected current behaviour
Added unit tests around behaviour new and existing behaviour
Reverted some changes from commit 9e8fd8e0091237a52c28af9f925c5edc225c837a to fix behaviour for
numeric type matching (looks like all unsigned numbers would come back as ulong, but before the commit best fit)

Fixed issues raised in:
http://stackoverflow.com/questions/17368027/override-parseprimitive-in-servicestack-text
http://stackoverflow.com/questions/13716838/how-to-get-servicestack-to-serialize-deserialize-an-expando-object-with-correc
