### PR TITLE
Test for abstract types in ReflectionExtensions.GetConstructorMethod

### DIFF
--- a/tests/ServiceStack.Text.Tests/ReflectionExtensionTests.cs
+++ b/tests/ServiceStack.Text.Tests/ReflectionExtensionTests.cs
@@ -52,5 +52,15 @@ namespace ServiceStack.Text.Tests
 
 			Serialize(model);
 		}
+
+		[Test]
+		public void Deals_with_abstract_types()
+		{
+			var t = typeof (IList<TestModel>);
+
+			ReflectionExtensions.GetConstructorMethodToCache(t);
+
+			Assert.Pass();
+		}
 	}
 }


### PR DESCRIPTION
This addresses the problem when one creates service with request DTO implementing, say, `IReturn<IList<Something>>` and tries to view metadata for that DTO. The MemberAccessException is thrown.

I'm not sure what is the correct way to fix this, so I've started just with single failing test.
