### PR TITLE
JsConfig.ExcludePropertyNames in scope

### DIFF
--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using ServiceStack.Text.Json;
 using ServiceStack.Text.Reflection;
@@ -123,7 +124,7 @@ namespace ServiceStack.Text.Common
             {
                 var propertyInfo = propertyInfos[i];
 
-                string propertyName, propertyNameCLSFriendly, propertyNameLowercaseUnderscore;
+                string propertyName, propertyNameCLSFriendly, propertyNameLowercaseUnderscore, propertyReflectedName;
 
                 if (isDataContract)
                 {
@@ -133,12 +134,14 @@ namespace ServiceStack.Text.Common
                     propertyName = dcsDataMember.Name ?? propertyInfo.Name;
                     propertyNameCLSFriendly = dcsDataMember.Name ?? propertyName.ToCamelCase();
                     propertyNameLowercaseUnderscore = dcsDataMember.Name ?? propertyName.ToLowercaseUnderscore();
+                    propertyReflectedName = dcsDataMember.Name ?? propertyInfo.ReflectedType.Name;
                 }
                 else
                 {
                     propertyName = propertyInfo.Name;
                     propertyNameCLSFriendly = propertyName.ToCamelCase();
                     propertyNameLowercaseUnderscore = propertyName.ToLowercaseUnderscore();
+                    propertyReflectedName = propertyInfo.ReflectedType.Name;
                 }
 
                 var propertyType = propertyInfo.PropertyType;
@@ -149,6 +152,7 @@ namespace ServiceStack.Text.Common
                 PropertyWriters[i] = new TypePropertyWriter
                 (
                     propertyName,
+                    propertyReflectedName,
                     propertyNameCLSFriendly,
                     propertyNameLowercaseUnderscore,
                     propertyInfo.GetValueGetter<T>(),
@@ -164,6 +168,7 @@ namespace ServiceStack.Text.Common
                 string propertyName = fieldInfo.Name;
                 string propertyNameCLSFriendly = propertyName.ToCamelCase();
                 string propertyNameLowercaseUnderscore = propertyName.ToLowercaseUnderscore();
+                string propertyReflectedName = fieldInfo.ReflectedType.Name;
 
                 var propertyType = fieldInfo.FieldType;
                 var suppressDefaultValue = propertyType.IsValueType() && JsConfig.HasSerializeFn.Contains(propertyType)
@@ -173,6 +178,7 @@ namespace ServiceStack.Text.Common
                 PropertyWriters[i + propertyNamesLength] = new TypePropertyWriter
                 (
                     propertyName,
+                    propertyReflectedName,
                     propertyNameCLSFriendly,
                     propertyNameLowercaseUnderscore,
                     fieldInfo.GetValueGetter<T>(),
@@ -198,16 +204,20 @@ namespace ServiceStack.Text.Common
                 }
             }
             internal readonly string propertyName;
+            internal readonly string propertyReflectedName;
+            internal readonly string propertyCombinedNameUpper;
             internal readonly string propertyNameCLSFriendly;
             internal readonly string propertyNameLowercaseUnderscore;
             internal readonly Func<T, object> GetterFn;
             internal readonly WriteObjectDelegate WriteFn;
             internal readonly object DefaultValue;
 
-            public TypePropertyWriter(string propertyName, string propertyNameCLSFriendly, string propertyNameLowercaseUnderscore,
-                Func<T, object> getterFn, WriteObjectDelegate writeFn, object defaultValue)
-            {
+            public TypePropertyWriter(string propertyName, string propertyReflectedName, string propertyNameCLSFriendly,
+                                      string propertyNameLowercaseUnderscore,
+                                      Func<T, object> getterFn, WriteObjectDelegate writeFn, object defaultValue) {
                 this.propertyName = propertyName;
+                this.propertyReflectedName = propertyReflectedName;
+                this.propertyCombinedNameUpper = (this.propertyReflectedName + "." + this.propertyName).ToUpper();
                 this.propertyNameCLSFriendly = propertyNameCLSFriendly;
                 this.propertyNameLowercaseUnderscore = propertyNameLowercaseUnderscore;
                 this.GetterFn = getterFn;
@@ -274,6 +284,8 @@ namespace ServiceStack.Text.Common
             if (PropertyWriters != null)
             {
                 var len = PropertyWriters.Length;
+                var exclude = JsConfig.ExcludePropertyNames ?? new string[0];
+                exclude = exclude.Select(x => x.ToUpper()).ToArray();
                 for (int index = 0; index < len; index++)
                 {
                     var propertyWriter = PropertyWriters[index];
@@ -285,9 +297,12 @@ namespace ServiceStack.Text.Common
                          || (propertyWriter.DefaultValue != null && propertyWriter.DefaultValue.Equals(propertyValue)))
                         && !Serializer.IncludeNullValues) continue;
 
+
+                    if (exclude.Any() && exclude.Contains(propertyWriter.propertyCombinedNameUpper)) continue;
+
                     if (i++ > 0)
                         writer.Write(JsWriter.ItemSeperator);
-
+                    
                     Serializer.WritePropertyName(writer, propertyWriter.PropertyName);
                     writer.Write(JsWriter.MapKeySeperator);
 

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -50,7 +50,8 @@ namespace ServiceStack.Text
             bool? escapeUnicode = null,
             bool? includePublicFields = null,
             int? maxDepth = null,
-            EmptyCtorFactoryDelegate modelFactory = null)
+            EmptyCtorFactoryDelegate modelFactory = null,
+            string[] excludePropertyNames = null)
         {
             return new JsConfigScope {
                 ConvertObjectTypesIntoStringDictionary = convertObjectTypesIntoStringDictionary ?? sConvertObjectTypesIntoStringDictionary,
@@ -75,6 +76,7 @@ namespace ServiceStack.Text
                 IncludePublicFields = includePublicFields ?? sIncludePublicFields,
                 MaxDepth = maxDepth ?? sMaxDepth,
                 ModelFactory = modelFactory ?? ModelFactory,
+                ExcludePropertyNames = excludePropertyNames ?? sExcludePropertyNames
             };
         }
 
@@ -523,8 +525,22 @@ namespace ServiceStack.Text
             }
         }
 
-
-	    public static void Reset()
+        /// <summary>
+        /// Set this so that you can exclude properties in scope.
+        /// The list should be the name of the object and the property.
+        /// Object Example, Property Id = "Example.Id"
+        /// </summary>
+        private static string[] sExcludePropertyNames;
+        public static string[] ExcludePropertyNames {
+            get {
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.ExcludePropertyNames : null)
+                       ??
+                       sExcludePropertyNames;
+            }
+            set { if (sExcludePropertyNames != null) sExcludePropertyNames = value; }
+        }
+        
+        public static void Reset()
         {
             foreach (var rawSerializeType in HasSerializeFn.ToArray())
             {
@@ -556,6 +572,7 @@ namespace ServiceStack.Text
             HasSerializeFn = new HashSet<Type>();
             TreatValueAsRefTypes = new HashSet<Type> { typeof(KeyValuePair<,>) };
             PropertyConvention = JsonPropertyConvention.ExactMatch;
+            sExcludePropertyNames = null;
         }
 
         public static void Reset(Type cachesForType)

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -79,5 +79,6 @@ namespace ServiceStack.Text
         public bool? IncludePublicFields { get; set; }
         public int? MaxDepth { get; set; }
         public EmptyCtorFactoryDelegate ModelFactory { get; set; }
+        public string[] ExcludePropertyNames { get; set; }
     }
 }

--- a/src/ServiceStack.Text/TypeConfig.cs
+++ b/src/ServiceStack.Text/TypeConfig.cs
@@ -45,15 +45,13 @@ namespace ServiceStack.Text
 		static TypeConfig()
 		{
 			config = new TypeConfig(typeof(T));
-			
 			var excludedProperties = JsConfig<T>.ExcludePropertyNames ?? new string[0];
-
             var properties = excludedProperties.Any()
-                ? config.Type.GetSerializableProperties().Where(x => !excludedProperties.Contains(x.Name))
-                : config.Type.GetSerializableProperties();
+                                     ? config.Type.GetSerializableProperties()
+                                             .Where(x => !excludedProperties.Contains(x.Name))
+                                     : config.Type.GetSerializableProperties();		        
             Properties = properties.Where(x => x.GetIndexParameters().Length == 0).ToArray();
-
-			Fields = config.Type.GetSerializableFields().ToArray();
+		    Fields = config.Type.GetSerializableFields().ToArray();
 		}
 
 		internal static TypeConfig GetState()

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -161,6 +161,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\tests\protobuf-net.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AdhocModelTests.cs" />


### PR DESCRIPTION
I needed to be able to exclude someproperties from my dtos per request. 
I added a new property ExcludePropertyNames to the JsConfig and to JSConfigScope.  I left the original JsConfig<T>.ExcludePropertyNames.  I am using the WriteType to check the propertyInfo.RefelectedType.Name +"." + propertyInfo.Name against the ExcludePropertyNames.  This way anything that you have set on the type JsConfig will still happen statically.  I added propertyReflectedName and propertyCombinedNameUpper to TypePropertyWriter.
