### PR TITLE
ExcludePropertyReferences

### DIFF
--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -50,7 +50,8 @@ namespace ServiceStack.Text
             bool? escapeUnicode = null,
             bool? includePublicFields = null,
             int? maxDepth = null,
-            EmptyCtorFactoryDelegate modelFactory = null)
+            EmptyCtorFactoryDelegate modelFactory = null,
+            string[] excludePropertyReferences = null)
         {
             return new JsConfigScope {
                 ConvertObjectTypesIntoStringDictionary = convertObjectTypesIntoStringDictionary ?? sConvertObjectTypesIntoStringDictionary,
@@ -75,6 +76,7 @@ namespace ServiceStack.Text
                 IncludePublicFields = includePublicFields ?? sIncludePublicFields,
                 MaxDepth = maxDepth ?? sMaxDepth,
                 ModelFactory = modelFactory ?? ModelFactory,
+                ExcludePropertyReferences = excludePropertyReferences ?? sExcludePropertyReferences
             };
         }
 
@@ -523,6 +525,16 @@ namespace ServiceStack.Text
             }
         }
 
+        private static string[] sExcludePropertyReferences;
+        public static string[] ExcludePropertyReferences {
+            get {
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.ExcludePropertyReferences : null)
+                       ?? sExcludePropertyReferences;
+            }
+            set {
+                if (sExcludePropertyReferences != null) sExcludePropertyReferences = value;
+            }
+        }
 
 	    public static void Reset()
         {
@@ -556,6 +568,7 @@ namespace ServiceStack.Text
             HasSerializeFn = new HashSet<Type>();
             TreatValueAsRefTypes = new HashSet<Type> { typeof(KeyValuePair<,>) };
             PropertyConvention = JsonPropertyConvention.ExactMatch;
+            sExcludePropertyReferences = null;
         }
 
         public static void Reset(Type cachesForType)

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -79,5 +79,6 @@ namespace ServiceStack.Text
         public bool? IncludePublicFields { get; set; }
         public int? MaxDepth { get; set; }
         public EmptyCtorFactoryDelegate ModelFactory { get; set; }
+        public string[] ExcludePropertyReferences { get; set; }
     }
 }

--- a/tests/ServiceStack.Text.Tests/AdhocModelTests.cs
+++ b/tests/ServiceStack.Text.Tests/AdhocModelTests.cs
@@ -334,6 +334,95 @@ namespace ServiceStack.Text.Tests
             Assert.That(dto.ToJsv(), Is.EqualTo("{Key:Value}"));
         }
 
+        [Test]
+        public void Can_exclude_properties_scoped() {
+            var dto = new Exclude {Id = 1, Key = "Value"};
+            using (var config = JsConfig.BeginScope()) {
+                config.ExcludePropertyReferences = new[] {"Exclude.Id"};
+                Assert.That(dto.ToJson(), Is.EqualTo("{\"Key\":\"Value\"}"));
+                Assert.That(dto.ToJsv(), Is.EqualTo("{Key:Value}"));
+            }
+        }
+        
+        public class IncludeExclude {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public Exclude Obj { get; set; }
+        }
+
+        [Test]
+        public void Can_include_nested_only() {
+            var dto = new IncludeExclude {
+                Id = 1234,
+                Name = "TEST",
+                Obj = new Exclude {
+                    Id = 1,
+                    Key = "Value"
+                }
+            };
+
+            using (var config = JsConfig.BeginScope()) {
+                config.ExcludePropertyReferences = new[] { "Exclude.Id", "IncludeExclude.Id", "IncludeExclude.Name" };
+                Assert.That(dto.ToJson(), Is.EqualTo("{\"Obj\":{\"Key\":\"Value\"}}"));
+                Assert.That(dto.ToJsv(), Is.EqualTo("{Obj:{Key:Value}}"));
+            }
+            Assert.That(JsConfig.ExcludePropertyReferences, Is.EqualTo(null));
+
+        }
+
+        [Test]
+        public void Exclude_all_nested()
+        {
+            var dto = new IncludeExclude
+            {
+                Id = 1234,
+                Name = "TEST",
+                Obj = new Exclude
+                {   
+                    Id = 1,
+                    Key = "Value"
+                }
+            };
+            
+            using (var config = JsConfig.BeginScope())
+            {
+                config.ExcludePropertyReferences = new[] { "Exclude.Id", "Exclude.Key" };
+                Assert.AreEqual(2, config.ExcludePropertyReferences.Length);
+
+                var actual = dto.ToJson();
+                Assert.That(actual, Is.EqualTo("{\"Id\":1234,\"Name\":\"TEST\",\"Obj\":{}}"));
+                Assert.That(dto.ToJsv(), Is.EqualTo("{Id:1234,Name:TEST,Obj:{}}"));
+            }
+        }
+
+        public class ExcludeList {
+            public int Id { get; set; }
+            public List<Exclude> Excludes { get; set; }
+        }
+
+        [Test]
+        public void Exclude_List_Scope() {
+            var dto = new ExcludeList {
+                Id = 1234,
+                Excludes = new List<Exclude>() {
+                    new Exclude {
+                        Id = 2345,
+                        Key = "Value"
+                    },
+                    new Exclude {
+                        Id = 3456,
+                        Key = "Value"
+                    }
+                }
+            };
+            using (var config = JsConfig.BeginScope())
+            {
+                config.ExcludePropertyReferences = new[] { "ExcludeList.Id", "Exclude.Id" };
+                Assert.That(dto.ToJson(), Is.EqualTo("{\"Excludes\":[{\"Key\":\"Value\"},{\"Key\":\"Value\"}]}"));
+                Assert.That(dto.ToJsv(), Is.EqualTo("{Excludes:[{Key:Value},{Key:Value}]}"));
+            }
+        }
+
         public class HasIndex
         {
             public int Id { get; set; }


### PR DESCRIPTION
I made the changes from pull request #358.  I added the JsConfig and JsConfigScope porperty ExcludePropertyReferences.  I added this so that properties could be excluded in scope.  Added tests to AdhocModelTests.cs
