### PR TITLE
Proper serialization of an object implementing IEnumerable<T>

### DIFF
--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -403,14 +403,14 @@ namespace ServiceStack.Text.Common
 
                     return (w, x) => writeFn(w, x, keyWriteFn, valueWriteFn);
                 }
+            }
 
-                var enumerableInterface = typeof(T).GetTypeWithGenericTypeDefinitionOf(typeof(IEnumerable<>));
-                if (enumerableInterface != null)
-                {
-                    var elementType = enumerableInterface.GenericTypeArguments()[0];
-                    var writeFn = WriteListsOfElements<TSerializer>.GetGenericWriteEnumerable(elementType);
-                    return writeFn;
-                }
+            var enumerableInterface = typeof(T).GetTypeWithGenericTypeDefinitionOf(typeof(IEnumerable<>));
+            if (enumerableInterface != null)
+            {
+                var elementType = enumerableInterface.GenericTypeArguments()[0];
+                var writeFn = WriteListsOfElements<TSerializer>.GetGenericWriteEnumerable(elementType);
+                return writeFn;
             }
 
             var isDictionary = typeof(T) != typeof(IEnumerable) && typeof(T) != typeof(ICollection)


### PR DESCRIPTION
This commit fixes an issue whereby child items of a class
implementing IEnumerable{T} would not get a __type field,
thereby making it impossible to deserialize the output.
The fix moved code that was meant to run on top of IEnumerable{T}
instances to a place where it will be checked in all circumstances.
Previously it would only be called when an object implements
IDictionary{K,V}.
