### PR TITLE
Fixed to build as SL5 project

### DIFF
--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -317,10 +317,7 @@ namespace ServiceStack.Text.Common
             {
                 var len = PropertyWriters.Length;
                 var exclude = JsConfig.ExcludePropertyReferences ?? new string[0];
-                for (var z = 0; z < exclude.Length; ++z)
-                {
-                    exclude[z] = exclude[z].ToUpper();
-                }
+                ConvertToUpper(exclude);
                 for (int index = 0; index < len; index++)
                 {
                     var propertyWriter = PropertyWriters[index];
@@ -413,6 +410,19 @@ namespace ServiceStack.Text.Common
             finally
             {
                 JsState.QueryStringMode = false;
+            }
+        }
+
+        /// <summary>
+        /// Converts all string values in <c>strArray</c> to uppercase
+        /// </summary>
+        /// <param name="strArray"></param>
+        private static void ConvertToUpper(string[] strArray)
+        {
+            for (var i = 0; i < strArray.Length; ++i)
+            {
+                if (strArray[i] != null)
+                    strArray[i] = strArray[i].ToUpper();
             }
         }
     }


### PR DESCRIPTION
Array.ConvertAll() is not available in SL5, rewritten to for loop.
