### PR TITLE
Removed UrlEncode from AppendUrlPaths method

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -310,7 +310,7 @@ namespace ServiceStack.Text
             foreach (var uriComponent in uriComponents)
             {
                 if (i++ > 0) sb.Append('/');
-                sb.Append(uriComponent.UrlEncode());
+                sb.Append(uriComponent);
             }
             return sb.ToString();
         }


### PR DESCRIPTION
Hi,

I was playing with https://github.com/ServiceStack/ServiceStack.Text/blob/master/tests/ServiceStack.Text.Tests/UseCases/GithubV3ApiTests.cs example.

After trying to get user "mythz" I got an error "404 not found". When I look at the url of the api call it was https://api.github.com/users%2fmythz 

After some search I found StringExtensions -> AppendUrlPaths. Removing UrlEncode solved my problem but I'm not sure if it is the real problem. The real problem might lie under UrlEncode function...

Regards
