### PR TITLE
append the "+0000" offset to utc dates if specified

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -35,6 +35,7 @@ namespace ServiceStack.Text.Common
         public const string WcfJsonPrefix = "/Date(";
         public const char WcfJsonSuffix = ')';
         public const string UnspecifiedOffset = "-0000";
+        public const string UtcOffset = "+0000";
 
         /// <summary>
         /// If AlwaysUseUtc is set to true then convert all DateTime to UTC.
@@ -422,6 +423,13 @@ namespace ServiceStack.Text.Common
                     offset = UnspecifiedOffset;
                 else
                     offset = LocalTimeZone.GetUtcOffset(dateTime).ToTimeOffsetString();
+            }
+            else
+            {
+                // Normally the JsonDateHandler.TimestampOffset doesn't append an offset for Utc dates, but if
+                // the JsConfig.AppendUtcOffset is set then we will
+                if (JsConfig.DateHandler == JsonDateHandler.TimestampOffset && JsConfig.AppendUtcOffset.HasValue && JsConfig.AppendUtcOffset.Value)
+                    offset = UtcOffset;
             }
 
             writer.Write(EscapedWcfJsonPrefix);

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -47,6 +47,7 @@ namespace ServiceStack.Text
 			bool? treatEnumAsInteger = null,
             bool? alwaysUseUtc = null,
             bool? assumeUtc = null,
+            bool? appendUtcOffset = null,
             bool? escapeUnicode = null,
             bool? includePublicFields = null,
             int? maxDepth = null,
@@ -72,6 +73,7 @@ namespace ServiceStack.Text
                 TreatEnumAsInteger = treatEnumAsInteger ?? sTreatEnumAsInteger,
                 AlwaysUseUtc = alwaysUseUtc ?? sAlwaysUseUtc,
                 AssumeUtc = assumeUtc ?? sAssumeUtc,
+                AppendUtcOffset = appendUtcOffset ?? sAppendUtcOffset,
                 EscapeUnicode = escapeUnicode ?? sEscapeUnicode,
                 IncludePublicFields = includePublicFields ?? sIncludePublicFields,
                 MaxDepth = maxDepth ?? sMaxDepth,
@@ -423,6 +425,26 @@ namespace ServiceStack.Text
         }
 
         /// <summary>
+        /// Gets or sets whether we should append the Utc offset when we serialize Utc dates. Defaults to no.
+        /// Only supported for when the JsConfig.DateHandler == JsonDateHandler.TimestampOffset
+        /// </summary>
+        private static bool? sAppendUtcOffset;
+        public static bool? AppendUtcOffset
+        {
+            // obeying the use of ThreadStatic, but allowing for setting JsConfig once as is the normal case
+            get
+            {
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.AppendUtcOffset : null)
+                    ?? sAppendUtcOffset
+                    ?? null;
+            }
+            set
+            {
+                if (sAppendUtcOffset == null) sAppendUtcOffset = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating if unicode symbols should be serialized as "\uXXXX".
         /// </summary>
         private static bool? sEscapeUnicode;
@@ -563,6 +585,7 @@ namespace ServiceStack.Text
 			sTreatEnumAsInteger = null;
             sAlwaysUseUtc = null;
             sAssumeUtc = null;
+            sAppendUtcOffset = null;
             sEscapeUnicode = null;
             sIncludePublicFields = null;
             HasSerializeFn = new HashSet<Type>();

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -74,6 +74,7 @@ namespace ServiceStack.Text
         public bool? ThrowOnDeserializationError { get; set; }
         public bool? AlwaysUseUtc { get; set; }
         public bool? AssumeUtc { get; set; }
+        public bool? AppendUtcOffset { get; set; }
         public bool? EscapeUnicode { get; set; }
         public bool? PreferInterfaces { get; set; }
         public bool? IncludePublicFields { get; set; }

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -134,6 +134,19 @@ namespace ServiceStack.Text.Tests.JsonTests
             JsConfig.Reset();
         }
 
+        [Test]
+        public void Can_serialize_json_date_timestampOffset_unspecified_appendUtcOffset()
+        {
+            JsConfig.DateHandler = JsonDateHandler.TimestampOffset;
+            JsConfig.AppendUtcOffset = true;
+
+            var dateTime = DateTime.SpecifyKind(DateTime.Parse("2013-06-14 19:43:37.663"), DateTimeKind.Utc);
+            var ssJson = JsonSerializer.SerializeToString(dateTime);
+            Assert.That(ssJson, Is.EqualTo(@"""\/Date(1371239017663+0000)\/"""));
+            
+            JsConfig.Reset();
+        }
+
 		#endregion
 
         #region TimeSpan Tests
@@ -252,6 +265,19 @@ namespace ServiceStack.Text.Tests.JsonTests
             Assert.That(ssJson, Is.EqualTo(@"""\/Date(1371239017663)\/"""));
             JsConfig.Reset();
         }
+
+        [Test]
+        public void Can_serialize_json_date_dcjsCompatible_unspecified_appendUtcOffset()
+        {
+            JsConfig.DateHandler = JsonDateHandler.DCJSCompatible;
+            JsConfig.AppendUtcOffset = true;
+
+            var dateTime = DateTime.SpecifyKind(DateTime.Parse("2013-06-14 19:43:37.663"), DateTimeKind.Utc);
+            var ssJson = JsonSerializer.SerializeToString(dateTime);
+            Assert.That(ssJson, Is.EqualTo(@"""\/Date(1371239017663)\/"""));
+
+            JsConfig.Reset();
+        }
 #endif
 		#endregion
 
@@ -365,6 +391,19 @@ namespace ServiceStack.Text.Tests.JsonTests
             var ssJson = JsonSerializer.SerializeToString(dateTime);
 
             Assert.That(ssJson, Is.EqualTo(@"""2013-06-14T19:43:37.6630000Z"""));
+            JsConfig.Reset();
+        }
+
+        [Test]
+        public void Can_serialize_json_date_iso8601_unspecified_appendUtcOffset()
+        {
+            JsConfig.DateHandler = JsonDateHandler.ISO8601;
+            JsConfig.AppendUtcOffset = true;
+
+            var dateTime = DateTime.SpecifyKind(DateTime.Parse("2013-06-14 19:43:37.663"), DateTimeKind.Utc);
+            var ssJson = JsonSerializer.SerializeToString(dateTime);
+            Assert.That(ssJson, Is.EqualTo(@"""2013-06-14T19:43:37.6630000Z"""));
+
             JsConfig.Reset();
         }
 


### PR DESCRIPTION
We, unfortunately, have some code out in the wild that doesn't parse utc dates unless they have the "+0000" offset at the end. I added a config option that will optionally add this offest for utc dates.

I've also added some unit tests and verified the current tests all pass:
650 passed, 0 failed, 12 skipped (see 'Task List'), took 5.23 seconds (NUnit 2.6.1).
