### PR TITLE
Prevent MethodAccessException in assembly name retrieval for Silverlight

### DIFF
--- a/src/ServiceStack.Text/AssemblyUtils.cs
+++ b/src/ServiceStack.Text/AssemblyUtils.cs
@@ -217,6 +217,8 @@ namespace ServiceStack.Text
             var codeBase = assembly.GetName().CodeBase;
 #elif NETFX_CORE
             var codeBase = assembly.GetName().FullName;
+#elif SILVERLIGHT
+            var codeBase = assembly.FullName;
 #else
             var codeBase = assembly.CodeBase;
 #endif


### PR DESCRIPTION
There was `MethodAccessException` thrown in Silverlight when we tried to access security critical property `Assembly.CodeBase`.
