### PR TITLE
Throw InvalidOperationException when DeserializeFromString<Dictionary<st...

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeDictionary.cs
+++ b/src/ServiceStack.Text/Common/DeserializeDictionary.cs
@@ -227,6 +227,9 @@ namespace ServiceStack.Text.Common
         private static int VerifyAndGetStartIndex(string value, Type createMapType)
         {
             var index = 0;
+            if(Serializer.EatListStartChar(value, ref index))
+                throw new InvalidOperationException(String.Format("Map definitions are not expected to be lists."));
+
             if (!Serializer.EatMapStartChar(value, ref index))
             {
                 //Don't throw ex because some KeyValueDataContractDeserializer don't have '{}'

--- a/src/ServiceStack.Text/Common/ITypeSerializer.cs
+++ b/src/ServiceStack.Text/Common/ITypeSerializer.cs
@@ -62,5 +62,6 @@ namespace ServiceStack.Text.Common
         void EatWhitespace(string value, ref int i);
         string EatValue(string value, ref int i);
         bool EatItemSeperatorOrMapEndChar(string value, ref int i);
+		bool EatListStartChar(string value, ref int i);
     }
 }

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -617,6 +617,15 @@ namespace ServiceStack.Text.Json
 
             return success;
         }
+		
+		public bool EatListStartChar(string value, ref int i)
+	    {
+            if (i == value.Length) return false;
+	        var success = value[i] == JsWriter.ListStartChar;
+            if (success)
+                i++;
+	        return success;
+	    }
 
         public void EatWhitespace(string value, ref int i)
         {

--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -358,6 +358,15 @@ namespace ServiceStack.Text.Jsv
 			i++;
 			return success;
 		}
+		
+		public bool EatListStartChar(string value, ref int i)
+	    {
+            if (i == value.Length) return false;
+	        var success = value[i] == JsWriter.ListStartChar;
+            if (success)
+                i++;
+	        return success;
+	    }
 
         public void EatWhitespace(string value, ref int i)
         {

--- a/tests/ServiceStack.Text.Tests/DataTests.cs
+++ b/tests/ServiceStack.Text.Tests/DataTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Northwind.Common.DataModel;
 using NUnit.Framework;
@@ -81,6 +82,12 @@ namespace ServiceStack.Text.Tests
 
 			Assert.That(response.Values, Has.Count.EqualTo(9));
 		}
-		
+
+	    [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+	    public void DeserializeFromString_For_Dictionary_Passing_In_List_Throws_InvalidOperationException()
+	    {
+	        TypeSerializer.DeserializeFromString<Dictionary<string, string>>("[{PropA:0}]");
+	    }
 	}
 }


### PR DESCRIPTION
...ring,string>> is passed a list

A key/value mapping is expected, so an InvalidOperationException is
preferred over an IndexOutOfRangeException, which is what is currently
occurring.
