### PR TITLE
Implmented tests and fixes for quoted properties and properties with comma in querystrings

### DIFF
--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -74,7 +74,10 @@ namespace ServiceStack.Text.Jsv
 		{
 			if (value != null)
 			{
-				writer.Write(value.ToString().EncodeJsv());
+                if(value is string)
+                    WriteString(writer, value as string);
+                else
+				    writer.Write(value.ToString().EncodeJsv());
 			}
 		}
 
@@ -85,6 +88,11 @@ namespace ServiceStack.Text.Jsv
 
 		public void WriteString(TextWriter writer, string value)
 		{
+            if(JsState.QueryStringMode && !string.IsNullOrEmpty(value) && value.StartsWith(JsWriter.QuoteString) && value.EndsWith(JsWriter.QuoteString))
+                value = String.Concat(JsWriter.QuoteChar, value, JsWriter.QuoteChar);
+		    else if (JsState.QueryStringMode && !string.IsNullOrEmpty(value) && value.Contains(JsWriter.ItemSeperatorString))
+		        value = String.Concat(JsWriter.QuoteChar, value, JsWriter.QuoteChar);
+            
 			writer.Write(value.EncodeJsv());
 		}
 

--- a/tests/ServiceStack.Text.Tests/QueryStringWriterTests.cs
+++ b/tests/ServiceStack.Text.Tests/QueryStringWriterTests.cs
@@ -49,7 +49,7 @@ namespace ServiceStack.Text.Tests
             queryString.Print();
 
             Assert.That(queryString,
-                Is.EqualTo("Id=tt0110912&Title=Pulp%20Fiction&Rating=8.9&Director=Quentin%20Tarantino&ReleaseDate=1994-10-24&TagLine=Girls%20like%20me%20don%27t%20make%20invitations%20like%20this%20to%20just%20anyone%21&Genres=Crime,Drama,Thriller"));
+                Is.EqualTo("Id=tt0110912&Title=Pulp%20Fiction&Rating=8.9&Director=Quentin%20Tarantino&ReleaseDate=1994-10-24&TagLine=Girls%20like%20me%20don%27t%20make%20invitations%20like%20this%20to%20just%20anyone%21&Genres=%22Crime,Drama,Thriller%22"));
         }
 
         [Test]

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -132,6 +132,7 @@
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>


### PR DESCRIPTION
Implmented tests and fixes for quoted properties and properties with comma in querystrings

Properties that had values that where quoted never kept their quotes when parsed
In jsv quotes have to be escaped with another quoted, this was not done for querystrings

Properties that had valus containing commas caused problems when parsing lists from
the querystring. By quoting these values the comma is parsed corectly on the way into
a service endpoint.

I hope you can get this into the v3, this would be a huge help to me.
