### PR TITLE
ToLowercaseUnderscore should not separate digits in property names.

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -692,7 +692,7 @@ namespace ServiceStack.Text
             var sb = new StringBuilder(value.Length);
             foreach (var t in value)
             {
-                if (Char.IsLower(t) || t == '_')
+                if (Char.IsDigit(t) || (Char.IsLetter(t) && Char.IsLower(t)) || t == '_')
                 {
                     sb.Append(t);
                 }

--- a/tests/ServiceStack.Text.Tests/JsonTests/LowercaseUnderscoreTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/LowercaseUnderscoreTests.cs
@@ -37,7 +37,7 @@ namespace ServiceStack.Text.Tests.JsonTests
             };
 
             var json = dto.ToJson();
-            
+
             Assert.That(json, Is.EqualTo(
                 "{\"id\":1,\"title\":\"The Shawshank Redemption\",\"imdb_id\":\"tt0111161\",\"rating\":9.2,\"director\":\"Frank Darabont\",\"release_date\":\"\\/Date(792979200000)\\/\",\"tag_line\":\"Fear can hold you prisoner. Hope can set you free.\",\"genres\":[\"Crime\",\"Drama\"]}"));
 
@@ -55,14 +55,21 @@ namespace ServiceStack.Text.Tests.JsonTests
 
         class WithUnderscore
         {
-            public int ? user_id { get; set; }
+            public int? user_id { get; set; }
+        }
+        class WithUnderscoreDigits
+        {
+            public int? user_id_0 { get; set; }
         }
 
         [Test]
         public void Should_not_put_double_underscore()
         {
-            var t = new WithUnderscore {user_id = 0};
+            var t = new WithUnderscore { user_id = 0 };
             Assert.That(t.ToJson(), Is.EqualTo("{\"user_id\":0}"));
+
+            var u = new WithUnderscoreDigits { user_id_0 = 0 };
+            Assert.That(u.ToJson(), Is.EqualTo("{\"user_id_0\":0}"));
         }
 
         [Test]
@@ -75,6 +82,19 @@ namespace ServiceStack.Text.Tests.JsonTests
             };
             Assert.That(TypeSerializer.SerializeToString(person), Is.EqualTo("{MyID:123,name:Abc}"));
             Assert.That(JsonSerializer.SerializeToString(person), Is.EqualTo("{\"MyID\":123,\"name\":\"Abc\"}"));
+        }
+
+
+        class WithUnderscoreSeveralDigits
+        {
+            public int? user_id_00_11 { get; set; }
+        }
+
+        [Test]
+        public void Should_not_split_digits()
+        {
+            var u = new WithUnderscoreSeveralDigits { user_id_00_11 = 0 };
+            Assert.That(u.ToJson(), Is.EqualTo("{\"user_id_00_11\":0}"));
         }
     }
 }


### PR DESCRIPTION
This addresses two related issues. 

First is that Should_not_put_double_underscore fails on a property name that contains digits. Property names "like_this_0" turn into names "like_this__0".

Second is that digits should not be split by underscores.

I found this when debugging ServiceStack.OrmLite.PostgreSQL.PostgreSqlNamingStrategy, a DTO with class Alias("click_trends_60m") was looking for "click_trends__6_0_m".
