### PR TITLE
Adds a failed LowercaseUnderscore Test to show regression

### DIFF
--- a/tests/ServiceStack.Text.Tests/JsonTests/LowercaseUnderscoreTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/LowercaseUnderscoreTests.cs
@@ -96,5 +96,17 @@ namespace ServiceStack.Text.Tests.JsonTests
             var u = new WithUnderscoreSeveralDigits { user_id_00_11 = 0 };
             Assert.That(u.ToJson(), Is.EqualTo("{\"user_id_00_11\":0}"));
         }
+
+        private class WithAbbreviationAndDigit
+        {
+            public string DigestHA1Hash { get; set; }
+        }
+
+        [Test]
+        public void Should_split_digit_after_abbreviation()
+        {
+            var a = new WithAbbreviationAndDigit() { DigestHA1Hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" };
+            Assert.That(a.ToJson(), Is.EqualTo("{\"digest_h_a_1_hash\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"));
+        }
     }
 }


### PR DESCRIPTION
Previous to version 3.9.66, sending `DigestHA1Hash` through ToLowerCaseUnderscore returned `digest_h_a_1_hash`. Now it returns `digest_h_a1_hash`
