### PR TITLE
Nullable<DateTimeOffset> Deserialization Fix

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -233,6 +233,13 @@ namespace ServiceStack.Text.Common
 
             return DateTimeOffset.Parse(dateTimeOffsetStr, CultureInfo.InvariantCulture);
         }
+		
+        public static DateTimeOffset? ParseDateTimeOffsetNullable(string dateTimeOffsetStr)
+        {
+            if (string.IsNullOrEmpty(dateTimeOffsetStr)) return null;
+
+            return ParseDateTimeOffset(dateTimeOffsetStr);
+        }
 
         public static string ToXsdDateTimeString(DateTime dateTime)
         {

--- a/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
+++ b/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
@@ -56,6 +56,8 @@ namespace ServiceStack.Text.Common
                 return value => DateTimeSerializer.ParseShortestNullableXsdDateTime(value);
             if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
                 return value => DateTimeSerializer.ParseShortestXsdDateTime(value);
+            if (typeof(T) == typeof(DateTimeOffset?))
+                return value => DateTimeSerializer.ParseDateTimeOffsetNullable(value);
             if (typeof(T) == typeof(DateTimeOffset) || typeof(T) == typeof(DateTimeOffset?))
                 return value => DateTimeSerializer.ParseDateTimeOffset(value);
             if (typeof(T) == typeof(TimeSpan))


### PR DESCRIPTION
Requesting this change to enable a DateTimeOffset? value to deserialize
to null properly when the JSON request's field is null or missing.
DateTime? already supports this functionality, but it appears to be
missing currently for DateTimeOffset?
