### PR TITLE
Fix a Null Pointer Exception on Deserialization

### DIFF
--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -377,7 +377,7 @@ namespace ServiceStack.Text.Jsv
 		{
 			var tokenStartPos = i;
 			var valueLength = value.Length;
-			if (i == valueLength) return null;
+			if (i == valueLength) return string.Empty;
 
 			var valueChar = value[i];
 			var withinQuotes = false;
@@ -388,7 +388,7 @@ namespace ServiceStack.Text.Jsv
 				//If we are at the end, return.
 				case JsWriter.ItemSeperator:
 				case JsWriter.MapEndChar:
-					return null;
+					return string.Empty;
 
 				//Is Within Quotes, i.e. "..."
 				case JsWriter.QuoteChar:


### PR DESCRIPTION
When deserializing a collection and a property of a serialized collection member has an empty value in the jsv file, I found out that the member can not be deserialized because of a null pointer exception. After my fix, everything was OK (no more exceptions).

The cause for that was found in the EatValue(..) method of JsvTypeSerializer: null was returned instead of an empty string at lines 380 and 391. That later caused a null exception when e.g. the UnescapeString(..) method of JsvTypeSerializer is called.
