### PR TITLE
Serialize fractional seconds correctly

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -338,10 +338,10 @@ namespace ServiceStack.Text.Common
         {
             var timeOfDay = dateTime.TimeOfDay;
 
-            if (timeOfDay.Ticks == 0)
+            if (IsStartOfDay(timeOfDay))
                 return dateTime.ToString(ShortDateTimeFormat);
 
-            if (timeOfDay.Milliseconds == 0)
+            if (!HasFractionalSeconds(timeOfDay))
                 return dateTime.Kind != DateTimeKind.Utc
                     ? dateTime.ToString(DateTimeFormatSecondsUtcOffset)
                     : dateTime.ToStableUniversalTime().ToString(XsdDateTimeFormatSeconds);
@@ -349,6 +349,16 @@ namespace ServiceStack.Text.Common
             return dateTime.Kind != DateTimeKind.Utc
                 ? dateTime.ToString(DateTimeFormatTicksUtcOffset)
                 : PclExport.Instance.ToXsdDateTimeString(dateTime);
+        }
+
+        private static bool IsStartOfDay(TimeSpan timeOfDay)
+        {
+            return timeOfDay.Ticks == 0;
+        }
+
+        private static bool HasFractionalSeconds(TimeSpan timeOfDay)
+        {
+            return (timeOfDay.Milliseconds != 0) || ((timeOfDay.Ticks % TimeSpan.TicksPerMillisecond) != 0);
         }
 
         static readonly char[] TimeZoneChars = new[] { '+', '-' };

--- a/tests/ServiceStack.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -202,7 +202,8 @@ namespace ServiceStack.Text.Tests.Utils
 			new DateTime(1979, 5, 9, 0, 0, 0, 1),
 			new DateTime(2010, 10, 20, 10, 10, 10, 1),
 			new DateTime(2010, 11, 22, 11, 11, 11, 1),
-            new DateTime(622119282055250000)
+            new DateTime(622119282055250000),
+            new DateTime(622119282050000001, DateTimeKind.Utc),
         };
 
         [Test]
@@ -215,6 +216,8 @@ namespace ServiceStack.Text.Tests.Utils
         [TestCase(6)]
         [TestCase(7)]
         [TestCase(8)]
+        [TestCase(9)]
+        [TestCase(10)]
         public void AssertDateIsEqual(int whichDate)
         {
             DateTime dateTime = DateTimeTests[whichDate];
@@ -245,6 +248,8 @@ namespace ServiceStack.Text.Tests.Utils
 
             var toDateTime = DateTimeSerializer.ParseShortestXsdDateTime(shortestDateStr);
             AssertDatesAreEqual(toDateTime, dateTime, "shortestDate");
+
+            Assert.That(toDateTime.ToStableUniversalTime().TimeOfDay.TotalSeconds, Is.EqualTo(dateTime.ToStableUniversalTime().TimeOfDay.TotalSeconds), "shortestDate: Fractional seconds differ");
 
             var unixTime = dateTime.ToUnixTimeMs();
             var fromUnixTime = DateTimeExtensions.FromUnixTimeMs(unixTime);


### PR DESCRIPTION
Fixed edge case where times between 0 and 1 milliseconds were not being serialized with any fractional seconds component.

This was causing some OrmLite.SQLite comparison operators (which are string based) to fail.

The problem was the `if (timeOfDay.Milliseconds == 0)` predicate used to detect if was OK to only serialize down to the seconds resolution, but not milliseconds.

That predicate isn't quite strong enough, since it omitted the fractional seconds when between 0 and 1 milliseconds (there are 10,000 ticks per millisecond).

Some of our SQlite-based unit tests were failing intermittently because there was a 1-in-1000 chance the serialization/deserialization was not symmetric.

Same bug exists in the v3.x branch.
