### PR TITLE
Fixed Url Encoding of spaces

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -150,6 +150,10 @@ namespace ServiceStack
                 {
                     sb.Append((char)charCode);
                 }
+                else if(charCode == 32)
+                {
+                    sb.Append('+');
+                }
                 else
                 {
                     sb.Append('%' + charCode.ToString("x2"));


### PR DESCRIPTION
Corrected UrlEncode so that it encodes a space to '+' instead of '%20'.
