### PR TITLE
Support field datamember serializing.

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeTypeRef.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRef.cs
@@ -36,16 +36,16 @@ namespace ServiceStack.Text.Common
         internal static Dictionary<string, TypeAccessor> GetTypeAccessorMap(TypeConfig typeConfig, ITypeSerializer serializer)
         {
             var type = typeConfig.Type;
+            var isDataContract = type.IsDto();
 
             var propertyInfos = type.GetSerializableProperties();
-            var fieldInfos = JsConfig.IncludePublicFields ? type.GetSerializableFields() : new FieldInfo[0];
+            var fieldInfos = JsConfig.IncludePublicFields || isDataContract ? type.GetSerializableFields() : new FieldInfo[0];
             if (propertyInfos.Length == 0 && fieldInfos.Length == 0) return null;
 
             var map = new Dictionary<string, TypeAccessor>(StringComparer.OrdinalIgnoreCase);
 
             if (propertyInfos.Length != 0)
             {
-                var isDataContract = type.IsDto();
                 foreach (var propertyInfo in propertyInfos)
                 {
                     var propertyName = propertyInfo.Name;

--- a/src/ServiceStack.Text/ReflectionExtensions.cs
+++ b/src/ServiceStack.Text/ReflectionExtensions.cs
@@ -539,7 +539,10 @@ namespace ServiceStack.Text
         public static FieldInfo[] GetSerializableFields(this Type type)
         {
             if (type.IsDto()) {
-                return new FieldInfo[0];
+                var allFields = type.GetAllFields();
+
+                // The contract must be honered 
+                return allFields.Where(prop => prop.CustomAttributes(false).Any(attr => attr.GetType().Name == DataMember)).ToArray();
             }
             
             var publicFields = type.GetPublicFields();
@@ -796,6 +799,21 @@ namespace ServiceStack.Text
             return type.GetRuntimeProperties().ToArray();
 #else
             return type.GetProperties();
+#endif
+        }
+
+        public static FieldInfo[] GetAllFields(this Type type)
+        {
+            if (type.IsInterface())
+            {
+                return new FieldInfo[0];
+            }
+
+#if NETFX_CORE
+            return type.GetRuntimeFields().Where(p => !p.IsStatic).ToArray();
+#else
+            return type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .ToArray();
 #endif
         }
 

--- a/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/BasicJsonTests.cs
@@ -299,6 +299,31 @@ namespace ServiceStack.Text.Tests.JsonTests
 		}
 #endif
 
+#if !MONOTOUCH
+        [DataContract]
+        class PersonDTO
+        {
+            [DataMember]
+            public int Id;
+
+            [DataMember]
+            public string Name { get; set; }
+        }
+
+        [Test]
+        public void Should_honor_datamember_attribute()
+        {
+            var person = new PersonDTO
+            {
+                Id = 123,
+                Name = "Abc"
+            };
+
+            Assert.That(TypeSerializer.SerializeToString(person), Is.EqualTo("{Id:123,Name:Abc}"));
+            Assert.That(JsonSerializer.SerializeToString(person), Is.EqualTo("{\"Id\":123,\"Name\":\"Abc\"}"));
+        }
+#endif
+
         [Flags]
         public enum ExampleEnum : ulong
         {


### PR DESCRIPTION
This _small_ change to handling field and DataContract serializing would remove a lot of pain for developers that is moving from WCF towards Servicestack. 
