### PR TITLE
Failing tests for deserialising clr type with string extensions "To" met...

### DIFF
--- a/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
+++ b/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
@@ -197,5 +197,36 @@ namespace ServiceStack.Text.Tests
             Assert.That("/path/info".TrimPrefixes("/www_deploy", "~/www_deploy"),
                 Is.EqualTo("/path/info"));
         }
+
+        public class TestObject
+        {
+            public int Index { get; set; }
+        }
+
+        [Test]
+        public void Can_deserialise_with_type()
+        {
+            string json = "{\"Index\":1}";
+            string objType = "\"ServiceStack.Text.Tests.StringExtensionsTests+TestObject, ServiceStack.Text.Tests\"";
+
+            Type t = objType.To<Type>();
+            object result = json.To(t);
+
+            Assert.That(((TestObject)result).Index, Is.EqualTo("1"));
+        }
+
+        [Test]
+        public void Can_deserialise_with_type_using_serialiser()
+        {
+            TestObject testObject = new TestObject() { Index = 1 };
+
+            string json = testObject.ToJson();
+            string objType = testObject.GetType().ToJson();
+
+            Type t = objType.To<Type>();
+            object result = json.To(t);
+
+            Assert.That(((TestObject)result).Index, Is.EqualTo("1"));
+        }
 	}
 }


### PR DESCRIPTION
I came across this behaviour which to me is a little unexpected.  Perhaps I should be using FromJson but there is no function that takes the type as a non generic parameter.

Thanks
Neil
