### PR TITLE
Fix an issue with nullable Enum to Enum conversion

### DIFF
--- a/src/ServiceStack.Text/AutoMappingUtils.cs
+++ b/src/ServiceStack.Text/AutoMappingUtils.cs
@@ -27,7 +27,7 @@ namespace ServiceStack
 
             if (from.GetType().IsValueType())
             {
-                return (T)Convert.ChangeType(from, typeof(T), provider:null);
+                return (T)Convert.ChangeType(from, typeof(T), provider: null);
             }
 
             if (typeof(IEnumerable).IsAssignableFromType(typeof(T)))
@@ -699,7 +699,7 @@ namespace ServiceStack
             {
                 if (toType.IsEnum() && fromType.IsEnum())
                 {
-                    return fromValue => Enum.Parse(toType, fromValue.ToString(), ignoreCase:true);
+                    return fromValue => Enum.Parse(toType, fromValue.ToString(), ignoreCase: true);
                 }
                 if (toType.IsNullableType())
                 {
@@ -711,11 +711,25 @@ namespace ServiceStack
                 }
                 else if (toType.IsIntegerType())
                 {
+                    if (fromType.IsNullableType())
+                    {
+                        var genericArg = fromType.GenericTypeArguments()[0];
+                        if (genericArg.IsEnum())
+                        {
+                            return fromValue => Enum.ToObject(genericArg, fromValue);
+                        }
+                    }
                     return fromValue => Enum.ToObject(fromType, fromValue);
                 }
             }
             else if (toType.IsNullableType())
             {
+                var toTypeBaseType = toType.GenericTypeArguments()[0];
+                if (toTypeBaseType.IsEnum())
+                {
+                    if (fromType.IsEnum() || (fromType.IsNullableType() && fromType.GenericTypeArguments()[0].IsEnum()))
+                        return fromValue => Enum.ToObject(toTypeBaseType, fromValue);
+                }
                 return null;
             }
             else if (typeof(IEnumerable).IsAssignableFromType(fromType))
@@ -730,13 +744,13 @@ namespace ServiceStack
             }
             else if (toType.IsValueType())
             {
-                return fromValue => Convert.ChangeType(fromValue, toType, provider:null);
+                return fromValue => Convert.ChangeType(fromValue, toType, provider: null);
             }
             else
             {
-                return fromValue => 
+                return fromValue =>
                 {
-                    if (fromValue == null) 
+                    if (fromValue == null)
                         return fromValue;
 
                     var toValue = toType.CreateInstance();

--- a/tests/ServiceStack.Text.Tests/AutoMappingTests.cs
+++ b/tests/ServiceStack.Text.Tests/AutoMappingTests.cs
@@ -93,6 +93,11 @@ namespace ServiceStack.Text.Tests
         public Color Color { get; set; }
     }
 
+    public class ReallyNullableEnumConversion
+    {
+        public Color? Color { get; set; }
+    }
+
     public class EnumConversion
     {
         public Color Color { get; set; }
@@ -209,7 +214,6 @@ namespace ServiceStack.Text.Tests
             var conversionDto = conversion.ConvertTo<NullableEnumConversionDto>();
 
             Assert.That(conversionDto.Color, Is.EqualTo(OtherColor.Green));
-
         }
 
         [Test]
@@ -219,6 +223,33 @@ namespace ServiceStack.Text.Tests
             var conversionDto = conversion.ConvertTo<EnumConversionDto>();
 
             Assert.That(conversionDto.Color, Is.EqualTo(OtherColor.Green));
+        }
+
+        [Test]
+        public void Does_ReallyEnumnullableconversion_translate()
+        {
+            var conversion = new ReallyNullableEnumConversion { Color = Color.Green };
+            var conversionDto = conversion.ConvertTo<NullableEnumConversionDto>();
+
+            Assert.That(conversionDto.Color, Is.EqualTo(OtherColor.Green));
+        }
+
+        [Test]
+        public void Does_RealyEnumconversion_translate()
+        {
+            var conversion = new ReallyNullableEnumConversion { Color = Color.Green };
+            var conversionDto = conversion.ConvertTo<EnumConversionDto>();
+
+            Assert.That(conversionDto.Color, Is.EqualTo(OtherColor.Green));
+        }
+
+        [Test]
+        public void Does_Enumconversion_translateFromNull()
+        {
+            var conversion = new ReallyNullableEnumConversion { Color = null };
+            var conversionDto = conversion.ConvertTo<EnumConversionDto>();
+
+            Assert.That(conversionDto.Color, Is.EqualTo(default(OtherColor)));
         }
 
         [Test]


### PR DESCRIPTION
In case of conversion from SomeEnum? to SomeEnum type property there was
an error, causing property to be populates with default Enum value
instead of correct one. Fixed by adding if-cases to CreateTypeConverter
code.
