### PR TITLE
Fix EmitDefaultValue support for Enums with custom SerializeFn.

### DIFF
--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -134,7 +134,7 @@ namespace ServiceStack.Text.Common
                 int propertyOrder = -1;
                 var propertyType = propertyInfo.PropertyType;
                 var defaultValue = propertyType.GetDefaultValue();
-                bool propertySuppressDefaultConfig = defaultValue != null && propertyType.IsValueType() && JsConfig.HasSerializeFn.Contains(propertyType);
+                bool propertySuppressDefaultConfig = defaultValue != null && propertyType.IsValueType() && !propertyType.IsEnum() && JsConfig.HasSerializeFn.Contains(propertyType);
                 bool propertySuppressDefaultAttribute = false;
 
                 var shouldSerialize = GetShouldSerializeMethod(propertyInfo);
@@ -183,7 +183,7 @@ namespace ServiceStack.Text.Common
                 int propertyOrder = -1;
                 var propertyType = fieldInfo.FieldType;
                 var defaultValue = propertyType.GetDefaultValue();
-                bool propertySuppressDefaultConfig = defaultValue != null && propertyType.IsValueType() && JsConfig.HasSerializeFn.Contains(propertyType);
+                bool propertySuppressDefaultConfig = defaultValue != null && propertyType.IsValueType() && !propertyType.IsEnum() && JsConfig.HasSerializeFn.Contains(propertyType);
                 bool propertySuppressDefaultAttribute = false;
 #if (NETFX_CORE)
                 var shouldSerialize = (Func<T, bool>)null;


### PR DESCRIPTION
Enums default values with a SerializeFn definined are never serialized in the current implementation. 
