### PR TITLE
Fixed a bug in StringExtensions.IndexOfAny()

### DIFF
--- a/src/ServiceStack.Text/StringExtensions.cs
+++ b/src/ServiceStack.Text/StringExtensions.cs
@@ -481,7 +481,7 @@ namespace ServiceStack
                 foreach (var needle in needles)
                 {
                     var pos = text.IndexOf(needle, startIndex);
-                    if (firstPos == -1 || pos < firstPos)
+                    if ((pos >= 0) && (firstPos == -1 || pos < firstPos))
                         firstPos = pos;
                 }
             }

--- a/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
+++ b/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
@@ -82,15 +82,19 @@ namespace ServiceStack.Text.Tests
 			Assert.That("path/to/file.ext".WithoutExtension(), Is.EqualTo("path/to/file"));
 		}
 
-		[Test]
-		public void Does_find_IndexOfAny_strings()
+        //         0         1
+        //         01234567890123456789
+        [TestCase("text with /* and <!--", "<!--", "/*", 10)]
+        [TestCase("text with /* and <!--", "<!--x", "/*", 10)]
+        [TestCase("text with /* and <!--", "<!--", "/*x", 17)]
+        [TestCase("text with /* and <!--", "<!--x", "/*x", -1)]
+        public void Does_find_IndexOfAny_strings(string text, string needle1, string needle2, int expectedPos)
 		{
-			var text = "text with /* and <!--";
-			var pos = text.IndexOfAny("<!--", "/*");
-			Assert.That(pos, Is.EqualTo("text with ".Length));
+			var pos = text.IndexOfAny(needle1, needle2);
+			Assert.That(pos, Is.EqualTo(expectedPos));
 		}
 
-		[Test]
+        [Test]
 		public void Does_ExtractContent_first_pattern_from_Document_without_marker()
 		{
 			var text = "text with random <!--comment--> and Contents: <!--Contents--> are here";


### PR DESCRIPTION
Previous version would only return the earliest position when all needles were present.
If the last needle was missing, -1 would be returned even if other needles were present.
