### PR TITLE
Adding async http string extension methods

### DIFF
--- a/src/ServiceStack.Text/HttpUtils.cs
+++ b/src/ServiceStack.Text/HttpUtils.cs
@@ -198,6 +198,172 @@ namespace ServiceStack
             return SendStringToUrl(url, method: "HEAD", accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
         }
 
+        public static Task<string> GetStringFromUrlAsync(this string url, string accept = "*/*",
+     Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PostStringToUrlAsync(this string url, string requestBody = null,
+            string contentType = null, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "POST",
+                requestBody: requestBody, contentType: contentType,
+                accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PostToUrlAsync(this string url, string formData = null, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "POST",
+                contentType: MimeTypes.FormUrlEncoded, requestBody: formData,
+                accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PostToUrlAsync(this string url, object formData = null, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            string postFormData = formData != null ? QueryStringSerializer.SerializeToString(formData) : null;
+
+            return SendStringToUrlAsync(url, method: "POST",
+                contentType: MimeTypes.FormUrlEncoded, requestBody: postFormData,
+                accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PostJsonToUrlAsync(this string url, string json,
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "POST", requestBody: json, contentType: MimeTypes.Json, accept: MimeTypes.Json,
+                requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PostJsonToUrlAsync(this string url, object data,
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "POST", requestBody: data.ToJson(), contentType: MimeTypes.Json, accept: MimeTypes.Json,
+                requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PostXmlToUrlAsync(this string url, string xml,
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "POST", requestBody: xml, contentType: MimeTypes.Xml, accept: MimeTypes.Xml,
+                requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PutStringToUrlAsync(this string url, string requestBody = null,
+            string contentType = null, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "PUT",
+                requestBody: requestBody, contentType: contentType,
+                accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PutToUrlAsync(this string url, string formData = null, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "PUT",
+                contentType: MimeTypes.FormUrlEncoded, requestBody: formData,
+                accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PutToUrlAsync(this string url, object formData = null, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            string postFormData = formData != null ? QueryStringSerializer.SerializeToString(formData) : null;
+
+            return SendStringToUrlAsync(url, method: "PUT",
+                contentType: MimeTypes.FormUrlEncoded, requestBody: postFormData,
+                accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PutJsonToUrlAsync(this string url, string json,
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "PUT", requestBody: json, contentType: MimeTypes.Json, accept: MimeTypes.Json,
+                requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PutJsonToUrlAsync(this string url, object data,
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "PUT", requestBody: data.ToJson(), contentType: MimeTypes.Json, accept: MimeTypes.Json,
+                requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> PutXmlToUrlAsync(this string url, string xml,
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "PUT", requestBody: xml, contentType: MimeTypes.Xml, accept: MimeTypes.Xml,
+                requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> DeleteFromUrlAsync(this string url, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "DELETE", accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> OptionsFromUrlAsync(this string url, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "OPTIONS", accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> HeadFromUrlAsync(this string url, string accept = "*/*",
+            Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)
+        {
+            return SendStringToUrlAsync(url, method: "HEAD", accept: accept, requestFilter: requestFilter, responseFilter: responseFilter);
+        }
+
+        public static Task<string> SendStringToUrlAsync(this string url, string method = null, string requestBody = null,
+            string contentType = null, string accept = "*/*", Action<HttpWebRequest> requestFilter = null,
+            Action<HttpWebResponse> responseFilter = null)
+        {
+            var webReq = (HttpWebRequest)WebRequest.Create(url);
+            if (method != null)
+                webReq.Method = method;
+            if (contentType != null)
+                webReq.ContentType = contentType;
+
+            webReq.Accept = accept;
+            PclExport.Instance.AddCompression(webReq);
+
+            if (requestFilter != null)
+            {
+                requestFilter(webReq);
+            }
+
+            if (requestBody != null)
+            {
+                using (var reqStream = PclExport.Instance.GetRequestStream(webReq))
+                using (var writer = new StreamWriter(reqStream))
+                {
+                    writer.Write(requestBody);
+                }
+            }
+
+            var taskWebRes = webReq.GetResponseAsync();
+
+            return taskWebRes.ContinueWith(task =>
+            {
+                var webRes = task.Result;
+
+                if (responseFilter != null)
+                {
+                    responseFilter(webRes);
+                }
+
+                using (var stream = webRes.GetResponseStream())
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            });
+        }
+
         public static string SendStringToUrl(this string url, string method = null,
             string requestBody = null, string contentType = null, string accept = "*/*",
             Action<HttpWebRequest> requestFilter = null, Action<HttpWebResponse> responseFilter = null)


### PR DESCRIPTION
I often use the `PostJsonToUrl` and similar string extension methods, but a lot of the time, I either don't care about the results, or want to receive them async style.  

I couldn't find the best way to do that with servicestack, so I just created more extension methods that instead return `Task<string>`.

Is this something you're interested in adding?

I don't know how to do this PCL style, so not sure how that part would work.

Anyway just throwin this out there for thoughts (implementation of async extensions could prolly be done better), let me know what you think.
