### PR TITLE
Update DateTimeSerializer.cs

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -205,7 +205,7 @@ namespace ServiceStack.Text.Common
                 var dateTime = new DateTime(int.Parse(dateParts[0]), int.Parse(dateParts[1]), int.Parse(dateParts[2]), hh, min, ss, ms, dateKind);
                 if (subMs != 0)
                 {
-                    dateTime.AddMilliseconds(subMs);
+                    dateTime=dateTime.AddMilliseconds(subMs);
                 }
 
                 if (offsetMultiplier != 0 && timeOffset != null)


### PR DESCRIPTION
Milliseconds are lost!
Fix "public static DateTime? ParseManual(string dateTimeStr)"
replace sentence : 
dateTime.AddMilliseconds(subMs);
with; 
dateTime = dateTime.AddMilliseconds(subMs);
