### PR TITLE
Don't bother title-casing property names for lenient lookup

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
@@ -29,16 +29,16 @@ namespace ServiceStack.Text.Common
         {
             TypeAccessor typeAccessor;
 
-            // camelCase is already supported by default, so no need to add another transform in the tree
-            return typeAccessorMap.TryGetValue(TransformFromLowercaseUnderscore(propertyName), out typeAccessor)
+            // map is case-insensitive by default, so simply remove hyphens and underscores
+            return typeAccessorMap.TryGetValue(RemoveSeparators(propertyName), out typeAccessor)
                        ? typeAccessor
                        : base.GetTypeAccessorForProperty(propertyName, typeAccessorMap);
         }
 
-        private static string TransformFromLowercaseUnderscore(string propertyName)
+        private static string RemoveSeparators(string propertyName)
         {
-            // "lowercase-hyphen" -> "lowercase_underscore" -> LowercaseUnderscore
-            return propertyName.Replace("-","_").ToTitleCase();
+            // "lowercase-hyphen" or "lowercase_underscore" -> lowercaseunderscore
+            return propertyName.Replace("-", String.Empty).Replace("_", String.Empty);
         }
 
     }


### PR DESCRIPTION
Profiling shows a significant amount of decoding time (>25%!) in this
hotspot when dealing with large, repetitive JSON documents using
underscore_style property names and requiring the leinent lookup.

The good news is there is no need to title case at all, once we remove
hyphens and underscores. The type accessor map uses a case-insensitive
lookup function, so any case will do. Note that no tests need modification
post-patch (although several would fail without the hyphen/underscore
removal).
