### PR TITLE
Cleanups

### DIFF
--- a/src/ServiceStack.Text/PclExport.Net40.cs
+++ b/src/ServiceStack.Text/PclExport.Net40.cs
@@ -167,7 +167,7 @@ namespace ServiceStack
             return Assembly.LoadFrom(assemblyPath);
         }
 
-        public virtual void AddHeader(WebRequest webReq, string name, string value)
+        public override void AddHeader(WebRequest webReq, string name, string value)
         {
             webReq.Headers.Add(name, value);
         }
@@ -199,13 +199,13 @@ namespace ServiceStack
             return assembly.CodeBase;
         }
 
-        public virtual string GetAssemblyPath(Type source)
+        public override string GetAssemblyPath(Type source)
         {
             var assemblyUri = new Uri(source.Assembly.EscapedCodeBase);
             return assemblyUri.LocalPath;
         }
 
-        public virtual string GetAsciiString(byte[] bytes, int index, int count)
+        public override string GetAsciiString(byte[] bytes, int index, int count)
         {
             return Encoding.ASCII.GetString(bytes, index, count);
         }
@@ -434,7 +434,7 @@ namespace ServiceStack
             return new XmlSerializer();
         }
 
-        public virtual void InitHttpWebRequest(HttpWebRequest httpReq,
+        public override void InitHttpWebRequest(HttpWebRequest httpReq,
             long? contentLength = null, bool allowAutoRedirect = true, bool keepAlive = true)
         {
             httpReq.UserAgent = Env.ServerUserAgent;
@@ -490,7 +490,7 @@ namespace ServiceStack
             Thread.BeginThreadAffinity();
         }
 
-        public virtual void EndThreadAffinity()
+        public override void EndThreadAffinity()
         {
             Thread.EndThreadAffinity();
         }
@@ -511,12 +511,12 @@ namespace ServiceStack
         }
 
 #if !__IOS__
-        public virtual SetPropertyDelegate GetSetPropertyMethod(PropertyInfo propertyInfo)
+        public override SetPropertyDelegate GetSetPropertyMethod(PropertyInfo propertyInfo)
         {
             return CreateIlPropertySetter(propertyInfo);
         }
 
-        public virtual SetPropertyDelegate GetSetFieldMethod(FieldInfo fieldInfo)
+        public override SetPropertyDelegate GetSetFieldMethod(FieldInfo fieldInfo)
         {
             return CreateIlFieldSetter(fieldInfo);
         }
@@ -537,17 +537,17 @@ namespace ServiceStack
             return type;
         }
 
-        public DataContractAttribute GetWeakDataContract(Type type)
+        public override DataContractAttribute GetWeakDataContract(Type type)
         {
             return type.GetWeakDataContract();
         }
 
-        public DataMemberAttribute GetWeakDataMember(PropertyInfo pi)
+        public override DataMemberAttribute GetWeakDataMember(PropertyInfo pi)
         {
             return pi.GetWeakDataMember();
         }
 
-        public DataMemberAttribute GetWeakDataMember(FieldInfo pi)
+        public override DataMemberAttribute GetWeakDataMember(FieldInfo pi)
         {
             return pi.GetWeakDataMember();
         }

--- a/src/ServiceStack.Text/PclExport.cs
+++ b/src/ServiceStack.Text/PclExport.cs
@@ -430,17 +430,17 @@ namespace ServiceStack
         {
         }
 
-        public DataContractAttribute GetWeakDataContract(Type type)
+        public virtual DataContractAttribute GetWeakDataContract(Type type)
         {
             return null;
         }
 
-        public DataMemberAttribute GetWeakDataMember(PropertyInfo pi)
+        public virtual DataMemberAttribute GetWeakDataMember(PropertyInfo pi)
         {
             return null;
         }
 
-        public DataMemberAttribute GetWeakDataMember(FieldInfo pi)
+        public virtual DataMemberAttribute GetWeakDataMember(FieldInfo pi)
         {
             return null;
         }


### PR DESCRIPTION
A few more changes after the performance fixes yesterday, thanks for looking so quickly at those!

The first might be a bit objectionable as it changes the public API, but the 'ToTitleCase' method is no longer used anywhere (in either ServiceStack proper or ServiceStack.Text), so it can be removed. This would also require a corresponding removal of the overrides in the ServiceStack Pcl libraries for Android, iOS, and .NET 4.5.

The second seems less crazy- there seems to be some mixups of override and virtual keyword usage.
