### PR TITLE
Fix: Allow deserialize pretty-printed JSON with type information

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -77,29 +77,34 @@ namespace ServiceStack.Text.Common
         public static Type ExtractType(string strType)
         {
             var typeAttrInObject = Serializer.TypeAttrInObject;
-            if (strType != null
-                && strType.Length > typeAttrInObject.Length
-                && strType.Substring(0, typeAttrInObject.Length) == typeAttrInObject)
+            if (strType != null && strType.Length > typeAttrInObject.Length)
             {
-                var propIndex = typeAttrInObject.Length;
-                var typeName = Serializer.UnescapeSafeString(Serializer.EatValue(strType, ref propIndex));
+                var propIndex = strType.IndexOf(typeAttrInObject, StringComparison.InvariantCulture);
 
-                var type = JsConfig.TypeFinder.Invoke(typeName);
-
-                if (type == null)
+                if (propIndex >= 1)
                 {
-                    Tracer.Instance.WriteWarning("Could not find type: " + typeName);
-                    return null;
-                }
+                    propIndex += typeAttrInObject.Length;
+                    var typeName = Serializer.UnescapeSafeString(Serializer.EatValue(strType, ref propIndex));
+
+                    var type = JsConfig.TypeFinder.Invoke(typeName);
+
+                    if (type == null)
+                    {
+                        Tracer.Instance.WriteWarning("Could not find type: " + typeName);
+                        return null;
+                    }
 
 #if !SILVERLIGHT && !MONOTOUCH
-                if (type.IsInterface || type.IsAbstract)
-                {
-                    return DynamicProxy.GetInstanceFor(type).GetType();
-                }
+                    if (type.IsInterface || type.IsAbstract)
+                    {
+                        return DynamicProxy.GetInstanceFor(type).GetType();
+                    }
 #endif
 
-                return type;
+                    return type;
+                    
+                }
+
             }
             return null;
         }
@@ -209,18 +214,21 @@ namespace ServiceStack.Text.Common
         {
             var typeAttrInObject = Serializer.TypeAttrInObject;
 
-            if (strType != null
-                && strType.Length > typeAttrInObject.Length
-                && strType.Substring(0, typeAttrInObject.Length) == typeAttrInObject)
+            if (strType != null && strType.Length > typeAttrInObject.Length)
             {
-                var propIndex = typeAttrInObject.Length;
-                var typeName = Serializer.EatValue(strType, ref propIndex);
-                var type = JsConfig.TypeFinder.Invoke(typeName);
+                var propIndex = strType.IndexOf(typeAttrInObject, StringComparison.InvariantCulture);
 
-                if (type == null)
-                    Tracer.Instance.WriteWarning("Could not find type: " + typeName);
+                if (propIndex >= 1)
+                {
+                    propIndex += typeAttrInObject.Length;
+                    var typeName = Serializer.EatValue(strType, ref propIndex);
+                    var type = JsConfig.TypeFinder.Invoke(typeName);
 
-                return type;
+                    if (type == null)
+                        Tracer.Instance.WriteWarning("Could not find type: " + typeName);
+
+                    return type;
+                }
             }
             return null;
         }

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -35,7 +35,7 @@ namespace ServiceStack.Text.Json
 
         internal static string GetTypeAttrInObject(string typeAttr)
         {
-            return string.Format("{{\"{0}\":", typeAttr);
+            return string.Format("\"{0}\":", typeAttr);
         }
 
         public static readonly bool[] WhiteSpaceFlags = new bool[' ' + 1];


### PR DESCRIPTION
When testing our services we realized that a pretty-printed JSON contain __type information cannot be properly deserialized (there can be whitespaces before __type):

``` c#
  [TestFixture]
    public class Class1
    {
        class MyClass : IComparable
        {
            public int CompareTo(object obj)
            {
                return 0;
            }
        }

        [Test]
        [TestCase("[{'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[{ '__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[{\n'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[{\t'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[ {'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[\n{'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[\t{'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[ { '__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[\n{\n'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[\t{\t'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[{'__type':'MyTest.Class1+MyClass'} ]")]
        [TestCase("[{ '__type':'MyTest.Class1+MyClass'}\t]")]
        [TestCase("[{\n'__type':'MyTest.Class1+MyClass'}\n]")]
        [TestCase("[{\t'__type':'MyTest.Class1+MyClass' }]")]
        [TestCase("[ {'__type':'MyTest.Class1+MyClass'\t}]")]
        [TestCase("[\n{'__type':'MyTest.Class1+MyClass'\n}]")]
        [TestCase("[\t{'__type':'MyTest.Class1+MyClass'\t}\n]")]
        [TestCase("[ { '__type':'MyTest.Class1+MyClass', }]")]
        [TestCase("[\n{\n'__type':'MyTest.Class1+MyClass'}]")]
        [TestCase("[\t{\t'__type':'MyTest.Class1+MyClass'}]")]
        public void TypeAttrInObject(string json)
        {
            json = json.Replace('\'', '"');
            var deserDto = JsonSerializer.DeserializeFromString<List<IComparable>>(json);
            Console.WriteLine(json);
            Assert.IsNotNull(deserDto);
            Assert.AreEqual(1, deserDto.Count);
            Assert.IsNotNull(deserDto[0]);
        }

    }
```
