### PR TITLE
Support white-space when parsing __type info

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -77,8 +77,17 @@ namespace ServiceStack.Text.Common
         public static Type ExtractType(string strType)
         {
             var typeAttrInObject = Serializer.TypeAttrInObject;
-            if (strType != null
-                && strType.Length > typeAttrInObject.Length
+            if (strType == null || strType.Length <= 1) return null;
+
+            var hasWhitespace = JsonUtils.WhiteSpaceChars.Contains(strType[1]);
+            if (hasWhitespace)
+            {
+                var pos = strType.IndexOf('"');
+                if (pos >= 0)
+                    strType = "{" + strType.Substring(pos);
+            }
+
+            if (strType.Length > typeAttrInObject.Length
                 && strType.Substring(0, typeAttrInObject.Length) == typeAttrInObject)
             {
                 var propIndex = typeAttrInObject.Length;

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -42,10 +42,10 @@ namespace ServiceStack.Text.Json
 
         static JsonTypeSerializer()
         {
-            WhiteSpaceFlags[' '] = true;
-            WhiteSpaceFlags['\t'] = true;
-            WhiteSpaceFlags['\r'] = true;
-            WhiteSpaceFlags['\n'] = true;
+            foreach (var c in JsonUtils.WhiteSpaceChars)
+            {
+                WhiteSpaceFlags[c] = true;
+            }
         }
 
         public WriteObjectDelegate GetWriteFn<T>()

--- a/src/ServiceStack.Text/Json/JsonUtils.cs
+++ b/src/ServiceStack.Text/Json/JsonUtils.cs
@@ -11,6 +11,8 @@ namespace ServiceStack.Text.Json
 		public const string True = "true";
 		public const string False = "false";
 
+        public static char[] WhiteSpaceChars = new[] { ' ', '\t', '\r', '\n' };
+
 		static readonly char[] EscapeChars = new[]
 			{
 				QuoteChar, '\n', '\r', '\t', '"', '\\', '\f', '\b',

--- a/tests/ServiceStack.Text.Tests/JsonTests/TypeInfoTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/TypeInfoTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+    public class TypeInfoTests
+    {
+        class MyClass : IComparable
+        {
+            public int CompareTo(object obj)
+            {
+                return 0;
+            }
+        }
+
+        [Test]
+        [TestCase("[{'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[{ '__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[{\n'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[{\t'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[ {'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[\n{'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[\t{'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[ { '__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[\n{\n'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[\t{\t'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[{'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'} ]")]
+        [TestCase("[{ '__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}\t]")]
+        [TestCase("[{\n'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}\n]")]
+        [TestCase("[{\t'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass' }]")]
+        [TestCase("[ {'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'\t}]")]
+        [TestCase("[\n{'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'\n}]")]
+        [TestCase("[\t{'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'\t}\n]")]
+        [TestCase("[ { '__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass', }]")]
+        [TestCase("[\n{\n'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        [TestCase("[\t{\t'__type':'ServiceStack.Text.Tests.JsonTests.TypeInfoTests+MyClass'}]")]
+        public void TypeAttrInObject(string json)
+        {
+            json = json.Replace('\'', '"');
+            var deserDto = JsonSerializer.DeserializeFromString<List<IComparable>>(json);
+            Console.WriteLine(json);
+            Assert.IsNotNull(deserDto);
+            Assert.AreEqual(1, deserDto.Count);
+            Assert.IsNotNull(deserDto[0]);
+        }
+ 
+    }
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -164,6 +164,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="JsonTests\TypeInfoTests.cs" />
     <Compile Include="AdhocModelTests.cs" />
     <Compile Include="AnonymousTypes.cs" />
     <Compile Include="AotTests.cs" />


### PR DESCRIPTION
According to recomendation in #430 this is almost 1:1 merge of 5c0ac5fc35ec4791eac3bf71cca142557b80e734

FYI: @pavelsavara 
