### PR TITLE
Fixed IEnumerable's with mixed types.

### DIFF
--- a/src/ServiceStack.Text/Common/WriteLists.cs
+++ b/src/ServiceStack.Text/Common/WriteLists.cs
@@ -179,10 +179,14 @@ namespace ServiceStack.Text.Common
 
             var valueCollection = (IEnumerable)oValueCollection;
             var ranOnce = false;
+            Type lastType = null;
             foreach (var valueItem in valueCollection)
             {
-                if (toStringFn == null)
-                    toStringFn = Serializer.GetWriteFn(valueItem.GetType());
+                if (toStringFn == null || valueItem.GetType() != lastType)
+                {
+                    lastType = valueItem.GetType();
+                    toStringFn = Serializer.GetWriteFn(lastType);
+                }
 
                 JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);
 

--- a/tests/ServiceStack.Text.Tests/EnumerableTests.cs
+++ b/tests/ServiceStack.Text.Tests/EnumerableTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace ServiceStack.Text.Tests
+{
+    [TestFixture]
+    public class EnumerableTests
+        : TestBase
+    {
+        [Test]
+        public void Can_serialize_array_list_of_mixed_types()
+        {
+            var list = (IEnumerable)new ArrayList {
+                1.0,
+                1.1,
+                1,
+                new object(),
+                "boo",
+                1,
+                1.2
+            };
+
+            Serialize(list);
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -176,6 +176,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EnumerableTests.cs" />
     <Compile Include="AttributeTests.cs" />
     <Compile Include="CsvTypeTests.cs" />
     <Compile Include="JsonTests\JsonEnumTests.cs" />


### PR DESCRIPTION
Serializing something like `new ArrayList { 1, 1.2 }` would fail with the following:

```
System.InvalidCastException : Specified cast is not valid.
   at ServiceStack.Text.Json.JsonTypeSerializer.WriteDouble(TextWriter writer, Object doubleValue)
   at ServiceStack.Text.Common.WriteListsOfElements`1.WriteIEnumerable(TextWriter writer, Object oValueCollection)
   at ServiceStack.Text.JsonSerializer.SerializeToString(T value)
```