### PR TITLE
Fixed possible corruption of thread local state.

### DIFF
--- a/src/ServiceStack.Text/Common/WriteDictionary.cs
+++ b/src/ServiceStack.Text/Common/WriteDictionary.cs
@@ -123,21 +123,33 @@ namespace ServiceStack.Text.Common
                 JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);
 
                 JsState.WritingKeyCount++;
-                JsState.IsWritingValue = false;
-
-                if (encodeMapKey)
+                try
                 {
-                    JsState.IsWritingValue = true; //prevent ""null""
-                    writer.Write(JsWriter.QuoteChar);
-                    writeKeyFn(writer, key);
-                    writer.Write(JsWriter.QuoteChar);
-                }
-                else
-                {
-                    writeKeyFn(writer, key);
-                }
+                    JsState.IsWritingValue = false;
 
-                JsState.WritingKeyCount--;
+                    if (encodeMapKey)
+                    {
+                        JsState.IsWritingValue = true; //prevent ""null""
+                        try
+                        {
+                            writer.Write(JsWriter.QuoteChar);
+                            writeKeyFn(writer, key);
+                            writer.Write(JsWriter.QuoteChar);
+                        }
+                        finally
+                        {
+                            JsState.IsWritingValue = false;
+                        }
+                    }
+                    else
+                    {
+                        writeKeyFn(writer, key);
+                    }
+                }
+                finally
+                {
+                    JsState.WritingKeyCount--;
+                }
 
                 writer.Write(JsWriter.MapKeySeperator);
 
@@ -155,8 +167,14 @@ namespace ServiceStack.Text.Common
                     }
 
                     JsState.IsWritingValue = true;
-                    writeValueFn(writer, dictionaryValue);
-                    JsState.IsWritingValue = false;
+                    try
+                    {
+                        writeValueFn(writer, dictionaryValue);
+                    }
+                    finally
+                    {
+                        JsState.IsWritingValue = false;
+                    }
                 }
             }
 
@@ -203,21 +221,26 @@ namespace ServiceStack.Text.Common
                 JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);
 
                 JsState.WritingKeyCount++;
-                JsState.IsWritingValue = false;
-
-                if (encodeMapKey)
+                try
                 {
-                    JsState.IsWritingValue = true; //prevent ""null""
-                    writer.Write(JsWriter.QuoteChar);
-                    writeKeyFn(writer, kvp.Key);
-                    writer.Write(JsWriter.QuoteChar);
-                }
-                else
-                {
-                    writeKeyFn(writer, kvp.Key);
-                }
+                    JsState.IsWritingValue = false;
 
-                JsState.WritingKeyCount--;
+                    if (encodeMapKey)
+                    {
+                        JsState.IsWritingValue = true; //prevent ""null""
+                        writer.Write(JsWriter.QuoteChar);
+                        writeKeyFn(writer, kvp.Key);
+                        writer.Write(JsWriter.QuoteChar);
+                    }
+                    else
+                    {
+                        writeKeyFn(writer, kvp.Key);
+                    }
+                }
+                finally
+                {
+                    JsState.WritingKeyCount--;
+                }
 
                 writer.Write(JsWriter.MapKeySeperator);
 
@@ -228,8 +251,14 @@ namespace ServiceStack.Text.Common
                 else
                 {
                     JsState.IsWritingValue = true;
-                    writeValueFn(writer, kvp.Value);
-                    JsState.IsWritingValue = false;
+                    try
+                    {
+                        writeValueFn(writer, kvp.Value);
+                    }
+                    finally
+                    {
+                        JsState.IsWritingValue = false;
+                    }
                 }
             }
 

--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -396,15 +396,21 @@ namespace ServiceStack.Text.Common
                     writer.Write(JsWriter.MapKeySeperator);
 
                     if (typeof(TSerializer) == typeof(JsonTypeSerializer)) JsState.IsWritingValue = true;
-                    if (propertyValue == null)
+                    try
                     {
-                        writer.Write(JsonUtils.Null);
+                        if (propertyValue == null)
+                        {
+                            writer.Write(JsonUtils.Null);
+                        }
+                        else
+                        {
+                            propertyWriter.WriteFn(writer, propertyValue);
+                        }
                     }
-                    else
+                    finally
                     {
-                        propertyWriter.WriteFn(writer, propertyValue);
+                        if (typeof(TSerializer) == typeof(JsonTypeSerializer)) JsState.IsWritingValue = false;
                     }
-                    if (typeof(TSerializer) == typeof(JsonTypeSerializer)) JsState.IsWritingValue = false;
                 }
             }
 

--- a/src/ServiceStack.Text/QueryStringSerializer.cs
+++ b/src/ServiceStack.Text/QueryStringSerializer.cs
@@ -168,17 +168,28 @@ namespace ServiceStack.Text
                         ranOnce = true;
 
                     JsState.WritingKeyCount++;
-                    JsState.IsWritingValue = false;
+                    try
+                    {
+                        JsState.IsWritingValue = false;
 
-                    writeKeyFn(writer, key);
-
-                    JsState.WritingKeyCount--;
+                        writeKeyFn(writer, key);
+                    }
+                    finally
+                    {
+                        JsState.WritingKeyCount--;
+                    }
 
                     writer.Write("=");
 
                     JsState.IsWritingValue = true;
-                    writeValueFn(writer, dictionaryValue);
-                    JsState.IsWritingValue = false;
+                    try
+                    {
+                        writeValueFn(writer, dictionaryValue);
+                    }
+                    finally
+                    {
+                        JsState.IsWritingValue = false;
+                    }
                 }
             }
             finally 

--- a/tests/ServiceStack.Text.Tests/DictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/DictionaryTests.cs
@@ -575,6 +575,33 @@ namespace ServiceStack.Text.Tests
             }
         }
 
+        [Test]
+        public void Can_recover_from_exceptions_when_serializing_dictionary_keys()
+        {
+            var before = JsConfig<int>.SerializeFn;
+            try
+            {
+                JsConfig<int>.SerializeFn = v =>
+                {
+                    throw new Exception("Boom!");
+                };
+                var target = new Dictionary<int, string>
+                {
+                    { 1, "1" },
+                };
+                Assert.Throws<Exception>(() => JsonSerializer.SerializeToString(target));
+            }
+            finally
+            {
+                JsConfig<int>.SerializeFn = before;
+            }
+            var json = JsonSerializer.SerializeToString(new ModelWithDictionary());
+
+            json.Print();
+
+            Assert.That(json.StartsWith("{"), Is.True);
+        }
+
         private class ModelWithDictionary
         {
             public Dictionary<string, string> Value { get; set; }


### PR DESCRIPTION
When this manifests the serializer will begin

writing things like this:
"{\"foo\":123}"

instead of this:
{"foo":123}