### PR TITLE
Fix null values serialization in ArrayList collection

### DIFF
--- a/src/ServiceStack.Text/Common/WriteLists.cs
+++ b/src/ServiceStack.Text/Common/WriteLists.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Linq;
+using ServiceStack.Text.Json;
 
 namespace ServiceStack.Text.Common
 {
@@ -182,10 +183,22 @@ namespace ServiceStack.Text.Common
             Type lastType = null;
             foreach (var valueItem in valueCollection)
             {
-                if (toStringFn == null || valueItem.GetType() != lastType)
+                if ((toStringFn == null) || (valueItem != null && valueItem.GetType() != lastType))
                 {
-                    lastType = valueItem.GetType();
-                    toStringFn = Serializer.GetWriteFn(lastType);
+                    if (valueItem != null)
+                    {
+                        if (valueItem.GetType() != lastType)
+                        {
+                            lastType = valueItem.GetType();
+                            toStringFn = Serializer.GetWriteFn(lastType);
+                        }
+                    }
+                    else
+                    {
+                        // this can happen if the first item in the collection was null
+                        lastType = typeof (object);
+                        toStringFn = Serializer.GetWriteFn(lastType);
+                    }
                 }
 
                 JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);

--- a/tests/ServiceStack.Text.Tests/EnumerableTests.cs
+++ b/tests/ServiceStack.Text.Tests/EnumerableTests.cs
@@ -26,5 +26,36 @@ namespace ServiceStack.Text.Tests
 
             Serialize(list);
         }
+
+        [Test]
+        public void Can_serialize_array_list_of_mixed_types_with_null()
+        {
+            var list = (IEnumerable)new ArrayList {
+                1.0,
+                null,
+                1,
+                new object(),
+                "boo",
+                1,
+                1.2
+            };
+
+            Serialize(list);
+        }
+
+        [Test]
+        public void Can_serialize_array_list_of_mixed_types_with_null_on_first_position()
+        {
+            var list = (IEnumerable)new ArrayList {
+                null,
+                1,
+                new object(),
+                "boo",
+                1,
+                1.2
+            };
+
+            Serialize(list);
+        }
     }
 }


### PR DESCRIPTION
* The issue here was even before previous change few weeks ago where presented only if the first item in collection was null.
* After the change it stopped working even if the first item in the collection was not null
* I didn't find a better way than using a default object serializer in such case