### PR TITLE
Invoke error handler callback for deserialization issues

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
@@ -162,9 +162,10 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
-                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, propType, e);
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationError(instance, propType, propertyName, propertyValueStr, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
-                        else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
+                        
+                        Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
                     }
                 }
 
@@ -181,9 +182,10 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
-                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, typeAccessor.PropertyType, e);
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationError(instance, typeAccessor.PropertyType, propertyName, propertyValueStr, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, typeAccessor.PropertyType, e);
-                        else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
+                        
+                        Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
                     }
                 }
                 else if (typeConfig.OnDeserializing != null)

--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
@@ -162,6 +162,7 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, propType, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
                         else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
                     }
@@ -180,6 +181,7 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, typeAccessor.PropertyType, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, typeAccessor.PropertyType, e);
                         else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
                     }

--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
@@ -112,6 +112,7 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, propType, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
                         else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
                     }
@@ -130,6 +131,7 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, propType, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
                         else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
                     }

--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJsv.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Reflection;
 using ServiceStack.Text.Json;
 using ServiceStack.Text.Jsv;
 
@@ -112,9 +110,10 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
-                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, propType, e);
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationError(instance, propType, propertyName, propertyValueStr, e);
                         if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
-                        else Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
+                        
+                        Tracer.Instance.WriteWarning("WARN: failed to set dynamic property {0} with: {1}", propertyName, propertyValueStr);
                     }
                 }
 
@@ -131,9 +130,10 @@ namespace ServiceStack.Text.Common
                     }
                     catch (Exception e)
                     {
-                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationErrorCallback(instance, propertyName, propertyValueStr, propType, e);
-                        if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, propType, e);
-                        else Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
+                        if (JsConfig.HasOnDeserializationErrorHandler) JsConfig.OnDeserializationError(instance, typeAccessor.PropertyType, propertyName, propertyValueStr, e);
+                        if (JsConfig.ThrowOnDeserializationError) throw DeserializeTypeRef.GetSerializationException(propertyName, propertyValueStr, typeAccessor.PropertyType, e);
+                        
+                        Tracer.Instance.WriteWarning("WARN: failed to set property {0} with: {1}", propertyName, propertyValueStr);
                     }
                 }
                 else if (typeConfig.OnDeserializing != null)

--- a/src/ServiceStack.Text/Common/JsDelegates.cs
+++ b/src/ServiceStack.Text/Common/JsDelegates.cs
@@ -33,4 +33,6 @@ namespace ServiceStack.Text.Common
     public delegate object ConvertObjectDelegate(object fromObject);
 
     public delegate object ConvertInstanceDelegate(object obj, Type type);
+
+    public delegate void DeserializationErrorDelegate(object instance, Type propertyType, string propertyName, string propertyValueStr, Exception e);
 }

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -15,6 +15,8 @@ namespace ServiceStack.Text
     public static class
         JsConfig
     {
+        public delegate void Action<in T1, in T2, in T3, in T4, in T5>(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5);
+
         static JsConfig()
         {
             //In-built default serialization, to Deserialize Color struct do:
@@ -387,6 +389,27 @@ namespace ServiceStack.Text
         }
 
         /// <summary>
+        /// Gets or sets a value indicating if the framework should call an error handler when
+        /// an exception happens during the deserialization.
+        /// </summary>
+        /// <remarks>Parameters have following meaning in order: deserialized entity, property name, parsed value, property type, caught exception.</remarks>
+        private static Action<object, string, string, Type, Exception> sOnDeserializationErrorCallback;
+        public static Action<object, string, string, Type, Exception> OnDeserializationErrorCallback
+        {
+            get
+            {
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.OnDeserializationErrorCallback : null)
+                    ?? sOnDeserializationErrorCallback;                
+            }
+            set { sOnDeserializationErrorCallback = value; }
+        }
+
+        /// <summary>
+        /// Gets whether a deserialization error handler is configured or not.
+        /// </summary>
+        public static bool HasOnDeserializationErrorHandler { get { return OnDeserializationErrorCallback != null; } }
+
+        /// <summary>
         /// Gets or sets a value indicating if the framework should always convert <see cref="DateTime"/> to UTC format instead of local time. 
         /// </summary>
         private static bool? sAlwaysUseUtc;
@@ -592,6 +615,7 @@ namespace ServiceStack.Text
             TreatValueAsRefTypes = new HashSet<Type> { typeof(KeyValuePair<,>) };
             PropertyConvention = JsonPropertyConvention.ExactMatch;
             sExcludePropertyReferences = null;
+	        sOnDeserializationErrorCallback = null;
         }
 
         public static void Reset(Type cachesForType)

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -15,8 +15,6 @@ namespace ServiceStack.Text
     public static class
         JsConfig
     {
-        public delegate void Action<in T1, in T2, in T3, in T4, in T5>(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5);
-
         static JsConfig()
         {
             //In-built default serialization, to Deserialize Color struct do:
@@ -393,21 +391,21 @@ namespace ServiceStack.Text
         /// an exception happens during the deserialization.
         /// </summary>
         /// <remarks>Parameters have following meaning in order: deserialized entity, property name, parsed value, property type, caught exception.</remarks>
-        private static Action<object, string, string, Type, Exception> sOnDeserializationErrorCallback;
-        public static Action<object, string, string, Type, Exception> OnDeserializationErrorCallback
+        private static DeserializationErrorDelegate sOnDeserializationError;
+        public static DeserializationErrorDelegate OnDeserializationError
         {
             get
             {
-                return (JsConfigScope.Current != null ? JsConfigScope.Current.OnDeserializationErrorCallback : null)
-                    ?? sOnDeserializationErrorCallback;                
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.OnDeserializationError : null)
+                    ?? sOnDeserializationError;                
             }
-            set { sOnDeserializationErrorCallback = value; }
+            set { sOnDeserializationError = value; }
         }
 
         /// <summary>
         /// Gets whether a deserialization error handler is configured or not.
         /// </summary>
-        public static bool HasOnDeserializationErrorHandler { get { return OnDeserializationErrorCallback != null; } }
+        public static bool HasOnDeserializationErrorHandler { get { return OnDeserializationError != null; } }
 
         /// <summary>
         /// Gets or sets a value indicating if the framework should always convert <see cref="DateTime"/> to UTC format instead of local time. 
@@ -615,7 +613,7 @@ namespace ServiceStack.Text
             TreatValueAsRefTypes = new HashSet<Type> { typeof(KeyValuePair<,>) };
             PropertyConvention = JsonPropertyConvention.ExactMatch;
             sExcludePropertyReferences = null;
-	        sOnDeserializationErrorCallback = null;
+	        sOnDeserializationError = null;
         }
 
         public static void Reset(Type cachesForType)

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -81,5 +81,6 @@ namespace ServiceStack.Text
         public int? MaxDepth { get; set; }
         public EmptyCtorFactoryDelegate ModelFactory { get; set; }
         public string[] ExcludePropertyReferences { get; set; }
+        public JsConfig.Action<object, string, string, Type, Exception> OnDeserializationErrorCallback { get; set; }
     }
 }

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Diagnostics;
+using ServiceStack.Text.Common;
 
 namespace ServiceStack.Text
 {
@@ -81,6 +82,6 @@ namespace ServiceStack.Text
         public int? MaxDepth { get; set; }
         public EmptyCtorFactoryDelegate ModelFactory { get; set; }
         public string[] ExcludePropertyReferences { get; set; }
-        public JsConfig.Action<object, string, string, Type, Exception> OnDeserializationErrorCallback { get; set; }
+        public DeserializationErrorDelegate OnDeserializationError { get; set; }
     }
 }

--- a/tests/ServiceStack.Text.Tests/JsonTests/OnDeserializationErrorCallbackTest.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/OnDeserializationErrorCallbackTest.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Runtime.Serialization;
+using NUnit.Framework;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+    [TestFixture]
+    public class OnDeserializationErrorCallbackTest
+    {
+        [Test]
+        public void Invokes_callback_on_protected_setter()
+        {
+            string json = @"{""idBadProt"":""value"", ""idGood"":""2"" }";
+
+            AssertThatInvalidJsonInvokesExpectedCallback<TestDto>(json, "idBadProt", "value", typeof(int), "Input string was not in a correct format.");
+        }
+
+        [Test]
+        public void Invokes_callback_on_incorrect_type()
+        {
+            string json = @"{""idBad"":""abc"", ""idGood"":""2"" }";
+            AssertThatInvalidJsonInvokesExpectedCallback<TestDto>(json, "idBad", "abc", typeof(int), "Input string was not in a correct format.");
+        }
+
+        [Test]
+        public void Invokes_callback_on_incorrect_type_with_data_set()
+        {
+            string json = @"{""idBad"":""abc"", ""idGood"":""2"" }";
+            AssertThatInvalidJsonInvokesExpectedCallback<TestDto>(json, "idBad", "abc", typeof(int), "Input string was not in a correct format.");
+        }        
+        
+        [Test]
+        public void Invokes_callback_on_value_out_of_range()
+        {
+            string json = @"{""idBad"":""4700000007"", ""idGood"":""2"" }";
+            AssertThatInvalidJsonInvokesExpectedCallback<TestDto>(json, "idBad", "4700000007", typeof(int), "Value was either too large or too small for an Int32.");
+        }
+
+        [Test]
+        public void Does_not_invoke_callback_on_valid_data()
+        {
+            JsConfig.Reset();
+            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) => Assert.Fail("For valida data this should not be invoked");
+
+            var json = @"{""idBad"":""2"", ""idGood"":""2"" }";
+            JsonSerializer.DeserializeFromString(json, typeof(TestDto));
+        }
+
+        [Test]
+        public void TestReset()
+        {
+            JsConfig.Reset();
+            Assert.IsNull(JsConfig.OnDeserializationErrorCallback);
+            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) => { };
+            Assert.IsNotNull(JsConfig.OnDeserializationErrorCallback);
+            JsConfig.Reset();
+            Assert.IsNull(JsConfig.OnDeserializationErrorCallback);
+        }
+
+        [Test]
+        public void Invokes_callback_deserialization_of_array_with_missing_comma()
+        {
+            string json = @"{""Values"": [ { ""Val"": ""a""} { ""Val"": ""b""}] }";
+
+            AssertThatInvalidJsonInvokesExpectedCallback<TestDtoWithArray>(json, "Values", @"[ { ""Val"": ""a""} { ""Val"": ""b""}]", typeof(TestChildDto[]), "Type definitions should start with a '{', expecting serialized type 'TestChildDto', got string starting with: Val");
+        }
+
+        [Test]
+        public void Does_not_invoke_callback_on_valid_data_with_array()
+        {
+            JsConfig.Reset();
+            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) => Assert.Fail("For valida data this should not be invoked");
+
+            var json = @"{""Values"": [ { ""Val"": ""a""}, { ""Val"": ""b""}] }";
+            JsonSerializer.DeserializeFromString(json, typeof(TestDtoWithArray));
+        }
+
+        [DataContract]
+        class TestDtoWithArray
+        {
+            [DataMember]
+            public TestChildDto[] Values { get; set; }
+        }
+
+        [DataContract]
+        class TestChildDto
+        {
+            [DataMember]
+            public string Val { get; set; }
+        }
+
+        [DataContract]
+        class TestDto
+        {
+            [DataMember(Name = "idBadProt")]
+            public int protId { get; protected set; }
+            [DataMember(Name = "idGood")]
+            public int IdGood { get; set; }
+            [DataMember(Name = "idBad")]
+            public int IdBad { get; set; }
+        }
+
+        private static void AssertThatInvalidJsonInvokesExpectedCallback<T>(string json, string expectedProperty, string expectedValue, Type expectedType, string expectedExceptionMessage)
+        {
+            string property = null, value = null;
+            Type type = null;
+            Exception ex = null;
+            bool callbackInvoked = false;
+            object deserialized = null;
+
+            JsConfig.Reset();
+            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) =>
+            {
+                deserialized = o;
+                property = s;
+                value = s1;
+                type = arg3;
+                ex = arg4;
+                callbackInvoked = true;
+            };
+
+
+            JsonSerializer.DeserializeFromString(json, typeof(T));
+
+            Assert.IsTrue(callbackInvoked, "Callback should be invoked");
+            Assert.AreEqual(expectedProperty, property);
+            Assert.AreEqual(expectedValue, value);
+            Assert.AreEqual(expectedType, type);
+            Assert.AreEqual(expectedExceptionMessage, ex.Message);
+            Assert.IsNotNull(deserialized);
+            Assert.IsInstanceOf<T>(deserialized);
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/JsonTests/OnDeserializationErrorCallbackTest.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/OnDeserializationErrorCallbackTest.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace ServiceStack.Text.Tests.JsonTests
 {
     [TestFixture]
-    public class OnDeserializationErrorCallbackTest
+    public class OnDeserializationErrorTest
     {
         [Test]
         public void Invokes_callback_on_protected_setter()
@@ -40,7 +40,7 @@ namespace ServiceStack.Text.Tests.JsonTests
         public void Does_not_invoke_callback_on_valid_data()
         {
             JsConfig.Reset();
-            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) => Assert.Fail("For valida data this should not be invoked");
+            JsConfig.OnDeserializationError = (o, s, s1, arg3, arg4) => Assert.Fail("For valida data this should not be invoked");
 
             var json = @"{""idBad"":""2"", ""idGood"":""2"" }";
             JsonSerializer.DeserializeFromString(json, typeof(TestDto));
@@ -50,11 +50,11 @@ namespace ServiceStack.Text.Tests.JsonTests
         public void TestReset()
         {
             JsConfig.Reset();
-            Assert.IsNull(JsConfig.OnDeserializationErrorCallback);
-            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) => { };
-            Assert.IsNotNull(JsConfig.OnDeserializationErrorCallback);
+            Assert.IsNull(JsConfig.OnDeserializationError);
+            JsConfig.OnDeserializationError = (o, s, s1, arg3, arg4) => { };
+            Assert.IsNotNull(JsConfig.OnDeserializationError);
             JsConfig.Reset();
-            Assert.IsNull(JsConfig.OnDeserializationErrorCallback);
+            Assert.IsNull(JsConfig.OnDeserializationError);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace ServiceStack.Text.Tests.JsonTests
         public void Does_not_invoke_callback_on_valid_data_with_array()
         {
             JsConfig.Reset();
-            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) => Assert.Fail("For valida data this should not be invoked");
+            JsConfig.OnDeserializationError = (o, s, s1, arg3, arg4) => Assert.Fail("For valida data this should not be invoked");
 
             var json = @"{""Values"": [ { ""Val"": ""a""}, { ""Val"": ""b""}] }";
             JsonSerializer.DeserializeFromString(json, typeof(TestDtoWithArray));
@@ -109,12 +109,12 @@ namespace ServiceStack.Text.Tests.JsonTests
             object deserialized = null;
 
             JsConfig.Reset();
-            JsConfig.OnDeserializationErrorCallback = (o, s, s1, arg3, arg4) =>
+            JsConfig.OnDeserializationError = (o, propertyType, s, s1, arg4) =>
             {
                 deserialized = o;
                 property = s;
                 value = s1;
-                type = arg3;
+                type = propertyType;
                 ex = arg4;
                 callbackInvoked = true;
             };

--- a/tests/ServiceStack.Text.Tests/JsonTests/ThrowOnDeserializeErrorTest.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/ThrowOnDeserializeErrorTest.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using NUnit.Framework;
-using ServiceStack.Text.Tests.Support;
 
 namespace ServiceStack.Text.Tests.JsonTests
 {

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="HashSetTests.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="HashtableTests.cs" />
+    <Compile Include="JsonTests\OnDeserializationErrorCallbackTest.cs" />
     <Compile Include="JsonTests\TypeInfoTests.cs" />
     <Compile Include="AdhocModelTests.cs" />
     <Compile Include="AnonymousTypes.cs" />


### PR DESCRIPTION
* Motivation:
  * We would have more detailed error logging related to serialization issues so we can help to users better diagnose API level issues
  * This change simply adds a generic hook for deserialization issues allowing to extend the parsed DTO with parsing errors as needed.
  * I'm not sure about the change in ```DeserializeTypeRefJsv```: The pre-existing code there seems to slightly differ for second of the exception handler where ```DeserializeTypeRefJson``` uses ```typeAccessor.PropertyType```. The Jsv implementation seems to be incorrect therefor.