### PR TITLE
Fixed DynamicsJson to parse arrays properly

### DIFF
--- a/src/ServiceStack.Text/Pcl.Dynamic.cs
+++ b/src/ServiceStack.Text/Pcl.Dynamic.cs
@@ -142,6 +142,15 @@ namespace ServiceStack
                     result = Deserialize(json);
                     return true;
                 }
+                else if (json.TrimStart(' ').StartsWith("[", StringComparison.Ordinal))
+                {
+                    result = JsonArrayObjects.Parse(json).Select(a =>
+                    {
+                        var hash = a.ToDictionary<KeyValuePair<string, string>, string, object>(entry => entry.Key, entry => entry.Value);
+                        return new DynamicJson(hash);
+                    }).ToArray();
+                    return true;
+                }
                 result = json;
                 return _hash[name] == result;
             }


### PR DESCRIPTION
Supporting properly parsing of arrays. Example:

```
var s = @"{ ""simple"": ""value"", ""obj"": { ""val"":""test"" }, ""array"": []";
var dyn = DynamicJson.Deserialize(s);
Console.WriteLine(dyn.simple);
Console.WriteLine(dyn.obj);
Console.WriteLine(dyn.obj.val);
Console.WriteLine(dyn.array);
```