### PR TITLE
Fixed SetQueryParam to set parameters correctly.

### DIFF
--- a/src/ServiceStack.Text/HttpUtils.cs
+++ b/src/ServiceStack.Text/HttpUtils.cs
@@ -40,7 +40,18 @@ namespace ServiceStack
             var qsPos = url.IndexOf('?');
             if (qsPos != -1)
             {
-                var existingKeyPos = url.IndexOf(key, qsPos, PclExport.Instance.InvariantComparison);
+                int existingKeyPos;
+                if(qsPos + 1 == url.IndexOf(key, qsPos, PclExport.Instance.InvariantComparison))
+                {
+                    existingKeyPos = qsPos + 1;
+                }
+                else
+                {
+                    existingKeyPos = url.IndexOf("&" + key, qsPos, PclExport.Instance.InvariantComparison);
+                    if (existingKeyPos != -1)
+                        existingKeyPos++;
+                }
+
                 if (existingKeyPos != -1)
                 {
                     var endPos = url.IndexOf('&', existingKeyPos);

--- a/tests/ServiceStack.Text.Tests/HttpUtilsTests.cs
+++ b/tests/ServiceStack.Text.Tests/HttpUtilsTests.cs
@@ -21,6 +21,7 @@ namespace ServiceStack.Text.Tests
             Assert.That("http://example.com?s=0".SetQueryParam("f", "1"), Is.EqualTo("http://example.com?s=0&f=1"));
             Assert.That("http://example.com?f=1".SetQueryParam("f", "2"), Is.EqualTo("http://example.com?f=2"));
             Assert.That("http://example.com?s=0&f=1&s=1".SetQueryParam("f", "2"), Is.EqualTo("http://example.com?s=0&f=2&s=1"));
+            Assert.That("http://example.com?s=rf&f=1".SetQueryParam("f", "2"), Is.EqualTo("http://example.com?s=rf&f=2"));
         }
 
         [Test]


### PR DESCRIPTION
The SetQueryParam method would search for the first occurrence of the param key string. And it would get a positive match even if the param key string was found inside a preceding parameters value.