### PR TITLE
Fix number with leading zeros serialization bug

### DIFF
--- a/src/ServiceStack.Text/JsonObject.cs
+++ b/src/ServiceStack.Text/JsonObject.cs
@@ -117,7 +117,7 @@ namespace ServiceStack.Text
             return base[key];
         }
         
-        static readonly Regex NumberRegEx = new Regex(@"^[0-9]*(?:\.[0-9]*)?$", PclExport.Instance.RegexOptions);
+        static readonly Regex NumberRegEx = new Regex(@"^(0|[1-9]*)(?:\.[0-9]*)?$", PclExport.Instance.RegexOptions);
 
         /// <summary>
         /// Write JSON Array, Object, bool or number values as raw string

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonObjectTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonObjectTests.cs
@@ -26,6 +26,27 @@ namespace ServiceStack.Text.Tests.JsonTests
             Assert.That(JsonObject.Parse("{ \n\t  \n\r}"), Is.Empty);
         }
 
+        [Test]
+        public void Can_Serialize_numbers()
+        {
+            string notNumber = "{\"field\":\"00001\"}";
+            Assert.AreEqual(notNumber, JsonObject.Parse(notNumber).ToJson<JsonObject>());
+
+            string num1 = "{\"field\":0}";
+            Assert.AreEqual(num1, JsonObject.Parse(num1).ToJson<JsonObject>());
+
+            string num2 = "{\"field\":0.5}";
+            Assert.AreEqual(num2, JsonObject.Parse(num2).ToJson<JsonObject>());
+
+            string num3 = "{\"field\":.5}";
+            Assert.AreEqual(num3, JsonObject.Parse(num3).ToJson<JsonObject>());
+
+            string num4 = "{\"field\":12312}";
+            Assert.AreEqual(num4, JsonObject.Parse(num4).ToJson<JsonObject>());
+
+            string num5 = "{\"field\":12312.1231}";
+            Assert.AreEqual(num5, JsonObject.Parse(num5).ToJson<JsonObject>());
+        }
 
         public class Jackalope
         {


### PR DESCRIPTION
JSON specification does not allow to use numbers with leading zeros
see http://stackoverflow.com/questions/29048110/override-json-deserializing-a-number-with-a-leading-zero-as-a-decimal-and-not-an/29048193#29048193
for more information