### PR TITLE
Security fix: Explicitly specified __type should not be even activated when not appropriate

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
+++ b/src/ServiceStack.Text/Common/DeserializeTypeRefJson.cs
@@ -91,36 +91,35 @@ namespace ServiceStack.Text.Common
                     var explicitTypeName = Serializer.ParseString(propertyValueStr);
                     var explicitType = AssemblyUtils.FindType(explicitTypeName);
 
-                    if (explicitType != null && !explicitType.IsInterface() && !explicitType.IsAbstract())
+                    // let's do the type safety checks first before we even attempt to create
+                    // a type instance
+                    if (explicitType == null || explicitType.IsInterface() || explicitType.IsAbstract())
+                    {
+                        Tracer.Instance.WriteWarning("Could not find type: " + propertyValueStr);
+                    }
+                    else if (!type.IsAssignableFrom(explicitType))
+                    {
+                        Tracer.Instance.WriteWarning("Could not assign type: " + propertyValueStr);
+                    }
+                    else
                     {
                         instance = explicitType.CreateInstance();
                     }
 
-                    if (instance == null)
+                    if (instance != null)
                     {
-                        Tracer.Instance.WriteWarning("Could not find type: " + propertyValueStr);
-                    }
-                    else
-                    {
-                        //If __type info doesn't match, ignore it.
-                        if (!type.InstanceOfType(instance))
+                        var derivedType = instance.GetType();
+                        if (derivedType != type)
                         {
-                            instance = null;
-                        }
-                        else
-                        {
-                            var derivedType = instance.GetType();
-                            if (derivedType != type)
+                            var derivedTypeConfig = new TypeConfig(derivedType);
+                            var map = DeserializeTypeRef.GetTypeAccessorMap(derivedTypeConfig, Serializer);
+                            if (map != null)
                             {
-                                var derivedTypeConfig = new TypeConfig(derivedType);
-                                var map = DeserializeTypeRef.GetTypeAccessorMap(derivedTypeConfig, Serializer);
-                                if (map != null)
-                                {
-                                    typeAccessorMap = map;
-                                }
+                                typeAccessorMap = map;
                             }
                         }
                     }
+
 
                     Serializer.EatItemSeperatorOrMapEndChar(strType, ref index);
                     continue;

--- a/tests/ServiceStack.Text.Tests/JsonTests/PolymorphicInstanceTest.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/PolymorphicInstanceTest.cs
@@ -44,5 +44,27 @@ namespace ServiceStack.Text.Tests.JsonTests
 
 		}
 
+        [Test]
+	    public void Should_not_even_instantiate_incorrect_type()
+	    {
+            var json = @"{""__type"":"""
+                           + typeof(TestClass).ToTypeString() + @""", ""Name"":""Fido""}";
+            var dog = JsonSerializer.DeserializeFromString<Dog>(
+
+                    json);
+
+            Assert.IsFalse(TestClass.Called);
+	    }
+
+	    public class TestClass 
+	    {
+            public static bool Called { get; set; }
+
+	        public TestClass()
+	        {
+	            Called = true;
+	        }
+	    }
+
 	}
 }


### PR DESCRIPTION
* I found that when you specify __type in the JSON the deserializer at first activates the instance and then runs the type check
* To me this seems to be a security issue since you can basically activate any object remotely
  * The class is immediately thrown away so no further code can be executed just what is inside the constructor
* I succesfully tested remote activation as well
