### PR TITLE
Fixes, cleanups, and optimizations

### DIFF
--- a/src/ServiceStack.Text/Json/JsonUtils.cs
+++ b/src/ServiceStack.Text/Json/JsonUtils.cs
@@ -1,161 +1,173 @@
 //Copyright (c) Service Stack LLC. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt
 
-using System;
 using System.IO;
 
 namespace ServiceStack.Text.Json
 {
-	public static class JsonUtils
-	{
-        public static long MaxInteger = 9007199254740992;
-        public static long MinInteger = -9007199254740992;
+    public static class JsonUtils
+    {
+        public const long MaxInteger = 9007199254740992;
+        public const long MinInteger = -9007199254740992;
 
-		public const char EscapeChar = '\\';
-		public const char QuoteChar = '"';
-		public const string Null = "null";
-		public const string True = "true";
-		public const string False = "false";
+        public const char EscapeChar = '\\';
+        public const char QuoteChar = '"';
+        public const string Null = "null";
+        public const string True = "true";
+        public const string False = "false";
+        
+        private const char TabChar = '\t';
+        private const char CarriageReturnChar = '\r';
+        private const char LineFeedChar = '\n';
+        private const char FormFeedChar = '\f';
+        private const char BackspaceChar = '\b';
 
-        public static char[] WhiteSpaceChars = new[] { ' ', '\t', '\r', '\n' };
+        /// <summary>
+        /// Micro-optimization keep pre-built char arrays saving a .ToCharArray() + function call (see .net implementation of .Write(string))
+        /// </summary>
+        private static readonly char[] EscapedBackslash = { EscapeChar, EscapeChar };
+        private static readonly char[] EscapedTab = { EscapeChar, TabChar };
+        private static readonly char[] EscapedCarriageReturn = { EscapeChar, CarriageReturnChar };
+        private static readonly char[] EscapedLineFeed = { EscapeChar, LineFeedChar };
+        private static readonly char[] EscapedFormFeed = { EscapeChar, FormFeedChar };
+        private static readonly char[] EscapedBackspace = { EscapeChar, BackspaceChar };
+        private static readonly char[] EscapedQuote = { EscapeChar, QuoteChar };
 
-		static readonly char[] EscapeChars = new[]
-			{
-				QuoteChar, '\n', '\r', '\t', '"', '\\', '\f', '\b',
-			};
+        public static readonly char[] WhiteSpaceChars = { ' ', TabChar, CarriageReturnChar, LineFeedChar };
 
-		private const int LengthFromLargestChar = '\\' + 1;
-		private static readonly bool[] EscapeCharFlags = new bool[LengthFromLargestChar];
+        public static void WriteString(TextWriter writer, string value)
+        {
+            if (value == null)
+            {
+                writer.Write(Null);
+                return;
+            }
+            if (!HasAnyEscapeChars(value))
+            {
+                writer.Write(QuoteChar);
+                writer.Write(value);
+                writer.Write(QuoteChar);
+                return;
+            }
 
-		static JsonUtils()
-		{
-			foreach (var escapeChar in EscapeChars)
-			{
-				EscapeCharFlags[escapeChar] = true;
-			}
-		}
+            var hexSeqBuffer = new char[4];
+            writer.Write(QuoteChar);
 
-		public static void WriteString(TextWriter writer, string value)
-		{
-			if (value == null)
-			{
-				writer.Write(JsonUtils.Null);
-				return;
-			}
-			if (!HasAnyEscapeChars(value))
-			{
-				writer.Write(QuoteChar);
-				writer.Write(value);
-				writer.Write(QuoteChar);
-				return;
-			}
-
-			var hexSeqBuffer = new char[4];
-			writer.Write(QuoteChar);
-
-			var len = value.Length;
+            var len = value.Length;
             for (var i = 0; i < len; i++)
             {
-                switch (value[i])
+                char c = value[i];
+
+                switch (c)
                 {
-                    case '\n':
-                        writer.Write("\\n");
+                    case LineFeedChar:
+                        writer.Write(EscapedLineFeed);
                         continue;
 
-                    case '\r':
-                        writer.Write("\\r");
+                    case CarriageReturnChar:
+                        writer.Write(EscapedCarriageReturn);
                         continue;
 
-                    case '\t':
-                        writer.Write("\\t");
+                    case TabChar:
+                        writer.Write(EscapedTab);
                         continue;
 
-                    case '"':
-                    case '\\':
-                        writer.Write('\\');
-                        writer.Write(value[i]);
+                    case QuoteChar:
+                        writer.Write(EscapedQuote);
                         continue;
 
-                    case '\f':
-                        writer.Write("\\f");
+                    case EscapeChar:
+                        writer.Write(EscapedBackslash);
                         continue;
 
-                    case '\b':
-                        writer.Write("\\b");
+                    case FormFeedChar:
+                        writer.Write(EscapedFormFeed);
+                        continue;
+
+                    case BackspaceChar:
+                        writer.Write(EscapedBackspace);
                         continue;
                 }
 
-                //Is printable char?
-                if (value[i] >= 32 && value[i] <= 126)
+                if (c.IsPrintable())
                 {
-                    writer.Write(value[i]);
+                    writer.Write(c);
                     continue;
                 }
 
                 // http://json.org/ spec requires any control char to be escaped
-                if (JsConfig.EscapeUnicode || char.IsControl(value[i]))
+                if (JsConfig.EscapeUnicode || char.IsControl(c))
                 {
                     // Default, turn into a \uXXXX sequence
-                    IntToHex(value[i], hexSeqBuffer);
+                    IntToHex(c, hexSeqBuffer);
                     writer.Write("\\u");
                     writer.Write(hexSeqBuffer);
                 }
                 else
-                    writer.Write(value[i]);
+                    writer.Write(c);
             }
 
-			writer.Write(QuoteChar);
-		}
+            writer.Write(QuoteChar);
+        }
 
-		/// <summary>
-		/// micro optimizations: using flags instead of value.IndexOfAny(EscapeChars)
-		/// </summary>
-		/// <param name="value"></param>
-		/// <returns></returns>
-		private static bool HasAnyEscapeChars(string value)
-		{
-			var len = value.Length;
-			for (var i = 0; i < len; i++)
-			{
-				var c = value[i];
+        private static bool IsPrintable(this char c)
+        {
+            return c >= 32 && c <= 126;
+        }
 
-                // non-printable
-                if (!(value[i] >= 32 && value[i] <= 126)) return true;
+        /// <summary>
+        /// Searches the string for one or more non-printable characters.
+        /// </summary>
+        /// <param name="value">The string to search.</param>
+        /// <returns>True if there are any characters that require escaping. False if the value can be written verbatim.</returns>
+        /// <remarks>
+        /// Micro optimizations: since quote and backslash are the only printable characters requiring escaping, removed previous optimization
+        /// (using flags instead of value.IndexOfAny(EscapeChars)) in favor of two equality operations saving both memory and CPU time.
+        /// Also slightly reduced code size by re-arranging conditions.
+        /// TODO: Possible Linq-only solution requires profiling: return value.Any(c => !c.IsPrintable() || c == QuoteChar || c == EscapeChar);
+        /// </remarks>
+        private static bool HasAnyEscapeChars(string value)
+        {
+            var len = value.Length;
+            for (var i = 0; i < len; i++)
+            {
+                var c = value[i];
+                
+                // c is not printable
+                // OR c is a printable that requires escaping (quote and backslash).
+                if (!c.IsPrintable() || c == QuoteChar || c == EscapeChar) return true;
+            }
+            return false;
+        }
 
-				if (c >= LengthFromLargestChar || !EscapeCharFlags[c]) continue;
-				return true;
-			}
-			return false;
-		}
+        // Micro optimized
+        public static void IntToHex(int intValue, char[] hex)
+        {
+            // TODO: test if unrolling loop is faster
+            for (var i = 3; i >= 0; i--)
+            {
+                var num = intValue & 0xF; // intValue % 16
 
-		public static void IntToHex(int intValue, char[] hex)
-		{
-			for (var i = 0; i < 4; i++)
-			{
-				var num = intValue % 16;
+                // 0x30 + num == '0' + num
+                // 0x37 + num == 'A' + (num - 10)
+                hex[i] = (char) ((num < 10 ? 0x30 : 0x37) + num);
 
-				if (num < 10)
-					hex[3 - i] = (char)('0' + num);
-				else
-					hex[3 - i] = (char)('A' + (num - 10));
+                intValue >>= 4;
+            }
+        }
 
-				intValue >>= 4;
-			}
-		}
+        public static bool IsJsObject(string value)
+        {
+            return !string.IsNullOrEmpty(value)
+                && value[0] == '{'
+                && value[value.Length - 1] == '}';
+        }
 
-		public static bool IsJsObject(string value)
-		{
-			return !string.IsNullOrEmpty(value)
-				&& value[0] == '{'
-				&& value[value.Length - 1] == '}';
-		}
-
-		public static bool IsJsArray(string value)
-		{
-			return !string.IsNullOrEmpty(value)
-				&& value[0] == '['
-				&& value[value.Length - 1] == ']';
-		}
-	}
-
+        public static bool IsJsArray(string value)
+        {
+            return !string.IsNullOrEmpty(value)
+                && value[0] == '['
+                && value[value.Length - 1] == ']';
+        }
+    }
 }


### PR DESCRIPTION
Quote listed twice in escape chars.  Modulus 16 == bitwise AND 0xF.  Re-arrange logic to reduce code size and complexity.  Use char variable instead of index operation in various places.  Use constants instead of mixed constants and literals.  Comment some of the optimizations/oddities.  Dropped wasteful EscapeCharFlags in favor of two equality operations for the only two printable characters that require escaping (quote and backslash).  Removed now unused EscapeChars, now unused static constructor.  Created IsPrintable.  Suggestion for Linq-based alternative to HaveAnyEscapeChars and potential for loop unrolling.