### PR TITLE
When ServiceStack is serializing a class that have a list of Class th…

### DIFF
--- a/src/ServiceStack.Text/Common/WriteType.cs
+++ b/src/ServiceStack.Text/Common/WriteType.cs
@@ -364,6 +364,13 @@ namespace ServiceStack.Text.Common
 
         public static void WriteProperties(TextWriter writer, object value)
         {
+            if (PropertyWriters != null && 
+                value.GetType().FullName != PropertyWriters.GetType().GetGenericArguments()[0].FullName)
+            {
+                WriteAbstractProperties(writer, value);
+                return;
+            }
+
             if (typeof(TSerializer) == typeof(JsonTypeSerializer) && JsState.WritingKeyCount > 0)
                 writer.Write(JsWriter.QuoteChar);
 

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -765,6 +765,10 @@ namespace ServiceStack.Text
         public static bool? IncludeTypeInfo = null;
 
         /// <summary>
+        /// For classes that inherit of non abstract class.
+        /// </summary>
+        public static bool TreatAsAbstract = false;
+        /// <summary>
         /// Never emit type info for this type
         /// </summary>
         public static bool? ExcludeTypeInfo = null;

--- a/src/ServiceStack.Text/JsonSerializer.Generic.cs
+++ b/src/ServiceStack.Text/JsonSerializer.Generic.cs
@@ -46,7 +46,7 @@ namespace ServiceStack.Text
 		{
 			if (value == null) return null;
 			if (typeof(T) == typeof(string)) return value as string;
-            if (typeof(T) == typeof(object) || typeof(T).IsAbstract() || typeof(T).IsInterface())
+            if (typeof(T) == typeof(object) || typeof(T).IsAbstract() || typeof(T).IsInterface() || JsConfig<T>.TreatAsAbstract)
             {
                 if (typeof(T).IsAbstract() || typeof(T).IsInterface()) JsState.IsWritingDynamic = true;
                 var result = JsonSerializer.SerializeToString(value, value.GetType());
@@ -70,7 +70,7 @@ namespace ServiceStack.Text
 				writer.Write(value);
 				return;
 			}
-            if (typeof(T) == typeof(object) || typeof(T).IsAbstract() || typeof(T).IsInterface())
+            if (typeof(T) == typeof(object) || typeof(T).IsAbstract() || typeof(T).IsInterface() || JsConfig<T>.TreatAsAbstract)
             {
                 if (typeof(T).IsAbstract() || typeof(T).IsInterface()) JsState.IsWritingDynamic = true;
                 JsonSerializer.SerializeToWriter(value, value.GetType(), writer);

--- a/src/ServiceStack.Text/JsonSerializer.cs
+++ b/src/ServiceStack.Text/JsonSerializer.cs
@@ -107,7 +107,7 @@ namespace ServiceStack.Text
             {
                 return SerializeToString(value, value.GetType());
             }
-            if (typeof(T).IsAbstract() || typeof(T).IsInterface())
+            if (typeof(T).IsAbstract() || typeof(T).IsInterface() || JsConfig<T>.TreatAsAbstract)
             {
                 JsState.IsWritingDynamic = true;
                 var result = SerializeToString(value, value.GetType());
@@ -158,7 +158,7 @@ namespace ServiceStack.Text
             {
                 SerializeToWriter(value, value.GetType(), writer);
             }
-		    else if (typeof(T).IsAbstract() || typeof(T).IsInterface())
+            else if (typeof(T).IsAbstract() || typeof(T).IsInterface() || JsConfig<T>.TreatAsAbstract)
 		    {
 		        JsState.IsWritingDynamic = false;
 		        SerializeToWriter(value, value.GetType(), writer);
@@ -189,7 +189,7 @@ namespace ServiceStack.Text
             {
                 SerializeToStream(value, value.GetType(), stream);
             }
-            else if (typeof(T).IsAbstract() || typeof(T).IsInterface())
+            else if (typeof(T).IsAbstract() || typeof(T).IsInterface() || JsConfig<T>.TreatAsAbstract)
             {
                 JsState.IsWritingDynamic = false;
                 SerializeToStream(value, value.GetType(), stream);

--- a/tests/ServiceStack.Text.Tests/JsonTests/InheritanceTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/InheritanceTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using ServiceStack.Text.Tests.Support;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+    class BlockBuster
+    {
+        public BlockBuster(string address)
+        {
+            this.Address = address;
+            this.Movies = new List<Movie>();
+        }
+
+        public string Address { get; set; }
+        public List<Movie> Movies { get; set; }
+    }
+
+
+    [TestFixture]
+    class InheritanceTests
+    {
+        [Test]
+        public void Can_serialize_class_with_list_that_classes_inherited_from_non_abstract_class_correctly()
+        {
+            var child = new MovieChild { ImdbId = "tt0068646", Title = "The Godfather", Rating = 9.2m, Director = "Francis Ford Coppola", ReleaseDate = new DateTime(1972, 3, 24), TagLine = "An offer you can't refuse.", Genres = new List<string> { "Crime", "Drama", "Thriller" }, };
+            child.Oscar.Add("Best Picture - 1972");
+            child.Oscar.Add("Best Actor - 1972");
+            child.Oscar.Add("Best Adapted Screenplay - 1972");
+
+            var blockBuster = new BlockBuster("Av. República do Líbano, 2175 - Indinópolis, São Paulo - SP, 04502-300");
+            blockBuster.Movies.Add(MoviesData.Movies[0]);
+            blockBuster.Movies.Add(child);
+
+            // serialize to JSON using ServiceStack
+            string jsonString = JsonSerializer.SerializeToString(blockBuster);
+
+            const string oldWaay = "{\"Address\":\"Av. República do Líbano, 2175 - Indinópolis, São Paulo - SP, 04502-300\",\"Movies\":[{\"Title\":\"The Shawshank Redemption\",\"ImdbId\":\"tt0111161\",\"Rating\":9.2,\"Director\":\"Frank Darabont\",\"ReleaseDate\":\"\\/Date(792990000000-0000)\\/\",\"TagLine\":\"Fear can hold you prisoner. Hope can set you free.\",\"Genres\":[\"Crime\",\"Drama\"]},{\"Title\":\"The Godfather\",\"ImdbId\":\"tt0068646\",\"Rating\":9.2,\"Director\":\"Francis Ford Coppola\",\"ReleaseDate\":\"\\/Date(70254000000-0000)\\/\",\"TagLine\":\"An offer you can't refuse.\",\"Genres\":[\"Crime\",\"Drama\",\"Thriller\"]}]}";
+            const string correct = "{\"Address\":\"Av. República do Líbano, 2175 - Indinópolis, São Paulo - SP, 04502-300\",\"Movies\":[{\"Title\":\"The Shawshank Redemption\",\"ImdbId\":\"tt0111161\",\"Rating\":9.2,\"Director\":\"Frank Darabont\",\"ReleaseDate\":\"\\/Date(792990000000-0000)\\/\",\"TagLine\":\"Fear can hold you prisoner. Hope can set you free.\",\"Genres\":[\"Crime\",\"Drama\"]},{\"__type\":\"ServiceStack.Text.Tests.Support.MovieChild, ServiceStack.Text.Tests\",\"Oscar\":[\"Best Picture - 1972\",\"Best Actor - 1972\",\"Best Adapted Screenplay - 1972\"],\"Title\":\"The Godfather\",\"ImdbId\":\"tt0068646\",\"Rating\":9.2,\"Director\":\"Francis Ford Coppola\",\"ReleaseDate\":\"\\/Date(70254000000-0000)\\/\",\"TagLine\":\"An offer you can't refuse.\",\"Genres\":[\"Crime\",\"Drama\",\"Thriller\"]}]}";
+
+            Assert.AreEqual(correct, jsonString, "Service stack serialized wrong");
+            Assert.IsFalse(oldWaay.Equals(correct));
+
+        }
+
+        [Test]
+        public void Can_set_that_class_is_abstract_in_jsonconfig()
+        {
+            JsConfig<Movie>.TreatAsAbstract = true;
+
+            var jsonString = JsonSerializer.SerializeToString(MoviesData.Movies[0]);
+
+            Assert.True(jsonString.Contains("__type"));
+        }
+
+    }
+
+
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -180,6 +180,7 @@
     <Compile Include="AttributeTests.cs" />
     <Compile Include="CsvTypeTests.cs" />
     <Compile Include="HttpUtilsTests.cs" />
+    <Compile Include="JsonTests\InheritanceTests.cs" />
     <Compile Include="JsonTests\JsonEnumTests.cs" />
     <Compile Include="JsonTests\InvalidJsonTests.cs" />
     <Compile Include="JsonTests\OnDeserializationErrorTests.cs" />

--- a/tests/ServiceStack.Text.Tests/Support/MovieDtos.cs
+++ b/tests/ServiceStack.Text.Tests/Support/MovieDtos.cs
@@ -5,9 +5,9 @@ using ServiceStack.DataAnnotations;
 
 namespace ServiceStack.Text.Tests.Support
 {
-	public static class MoviesData
-	{
-		public static List<Movie> Movies = new List<Movie>
+    public static class MoviesData
+    {
+        public static List<Movie> Movies = new List<Movie>
 		{
 			new Movie { ImdbId = "tt0111161", Title = "The Shawshank Redemption", Rating = 9.2m, Director = "Frank Darabont", ReleaseDate = new DateTime(1995,2,17), TagLine = "Fear can hold you prisoner. Hope can set you free.", Genres = new List<string>{"Crime","Drama"}, },
 			new Movie { ImdbId = "tt0068646", Title = "The Godfather", Rating = 9.2m, Director = "Francis Ford Coppola", ReleaseDate = new DateTime(1972,3,24), TagLine = "An offer you can't refuse.", Genres = new List<string> {"Crime","Drama", "Thriller"}, },
@@ -15,20 +15,20 @@ namespace ServiceStack.Text.Tests.Support
 			new Movie { ImdbId = "tt0071562", Title = "The Godfather: Part II", Rating = 9.0m, Director = "Francis Ford Coppola", ReleaseDate = new DateTime(1974,12,20), Genres = new List<string> {"Crime","Drama", "Thriller"}, },
 			new Movie { ImdbId = "tt0060196", Title = "The Good, the Bad and the Ugly", Rating = 9.0m, Director = "Sergio Leone", ReleaseDate = new DateTime(1967,12,29), TagLine = "They formed an alliance of hate to steal a fortune in dead man's gold", Genres = new List<string>{"Adventure","Western"}, },
 		};
-		
-	}
 
-	[DataContract]
-	public class Movie
-	{
-		public Movie()
-		{
-			this.Genres = new List<string>();
-		}
+    }
+
+    [DataContract]
+    public class Movie
+    {
+        public Movie()
+        {
+            this.Genres = new List<string>();
+        }
 
         [DataMember(EmitDefaultValue = false, IsRequired = false)]
         [AutoIncrement]
-		public int Id { get; set; }
+        public int Id { get; set; }
 
         [DataMember(Order = 3, EmitDefaultValue = false, IsRequired = false)]
         public string ImdbId { get; set; }
@@ -51,34 +51,46 @@ namespace ServiceStack.Text.Tests.Support
         [DataMember(Order = 8, EmitDefaultValue = false, IsRequired = false)]
         public List<string> Genres { get; set; }
 
-		#region AutoGen ReSharper code, only required by tests
-		public bool Equals(Movie other)
-		{
-			if (ReferenceEquals(null, other)) return false;
-			if (ReferenceEquals(this, other)) return true;
-			return Equals(other.ImdbId, ImdbId)
-				&& Equals(other.Title, Title)
-				&& other.Rating == Rating
-				&& Equals(other.Director, Director)
-				&& other.ReleaseDate.Equals(ReleaseDate)
-				&& Equals(other.TagLine, TagLine)
-				&& Genres.EquivalentTo(other.Genres);
-		}
+        #region AutoGen ReSharper code, only required by tests
+        public bool Equals(Movie other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(other.ImdbId, ImdbId)
+                && Equals(other.Title, Title)
+                && other.Rating == Rating
+                && Equals(other.Director, Director)
+                && other.ReleaseDate.Equals(ReleaseDate)
+                && Equals(other.TagLine, TagLine)
+                && Genres.EquivalentTo(other.Genres);
+        }
 
-		public override bool Equals(object obj)
-		{
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			if (obj.GetType() != typeof(Movie)) return false;
-			return Equals((Movie)obj);
-		}
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(Movie)) return false;
+            return Equals((Movie)obj);
+        }
 
-		public override int GetHashCode()
-		{
-			return ImdbId != null ? ImdbId.GetHashCode() : 0;
-		}
-		#endregion
-	}
+        public override int GetHashCode()
+        {
+            return ImdbId != null ? ImdbId.GetHashCode() : 0;
+        }
+        #endregion
+    }
+
+    [DataContract]
+    public class MovieChild : Movie
+    {
+        public MovieChild()
+        {
+            this.Oscar = new List<string>();
+        }
+
+        [DataMember]
+        public List<string> Oscar { get; set; }
+    }
 
     [DataContract]
     public class MovieResponse


### PR DESCRIPTION
When ServiceStack is serializing a class that have a list of Class that was inherited by another classes, it don't serialize all members from inherited class.

Example:
```csharp
class BlockBuster
{
	public BlockBuster(string address)
	{
		this.Address = address;
		this.Movies = new List<Movie>();
	}

	public string Address { get; set; }
	public List<Movie> Movies { get; set; }
}

[DataContract]
public class MovieChild : Movie
{
	public MovieChild() { this.Oscar = new List<string>(); }

	[DataMember]
	public List<string> Oscar { get; set; }
}
```
// Now a test:

```csharp
[Test]
public void Can_serialize_class_with_list_that_classes_inherited_from_non_abstract_class_correctly()
{
	var child = new MovieChild { ImdbId = "tt0068646", Title = "The Godfather", Rating = 9.2m, Director = "Francis Ford Coppola", ReleaseDate = new DateTime(1972, 3, 24), TagLine = "An offer you can't refuse.", Genres = new List<string> { "Crime", "Drama", "Thriller" }, };
	child.Oscar.Add("Best Picture - 1972");
	child.Oscar.Add("Best Actor - 1972");
	child.Oscar.Add("Best Adapted Screenplay - 1972");

	var blockBuster = new BlockBuster("Av. República do Líbano, 2175 - Indinópolis, São Paulo - SP, 04502-300");
	blockBuster.Movies.Add(MoviesData.Movies[0]);
	blockBuster.Movies.Add(child);

	// serialize to JSON using ServiceStack
	string jsonString = JsonSerializer.SerializeToString(blockBuster);
}
```
The JSON result:
```javascript
{
    "Oscar": ["Best Picture - 1972", "Best Actor - 1972", "Best Adapted Screenplay - 1972"],
    "Title": "The Godfather",
    "ImdbId": "tt0068646",
    "Rating": 9.2,
    "Director": "Francis Ford Coppola",
    "ReleaseDate": "\/Date(70254000000-0000)\/",
    "TagLine": "An offer you can't refuse.",
    "Genres": ["Crime", "Drama", "Thriller"]
}

{
    "Address": "Av. República do Líbano, 2175 - Indinópolis, São Paulo - SP, 04502-300",
    "Movies": [{
        "Title": "The Shawshank Redemption",
        "ImdbId": "tt0111161",
        "Rating": 9.2,
        "Director": "Frank Darabont",
        "ReleaseDate": "\/Date(792990000000-0000)\/",
        "TagLine": "Fear can hold you prisoner. Hope can set you free.",
        "Genres": ["Crime", "Drama"]
    }, {
        "Title": "The Godfather",
        "ImdbId": "tt0068646",
        "Rating": 9.2,
        "Director": "Francis Ford Coppola",
        "ReleaseDate": "\/Date(70254000000-0000)\/",
        "TagLine": "An offer you can't refuse.",
        "Genres": ["Crime", "Drama", "Thriller"]
    }]
}
```
The properties from MovieChild was't serialized.

These changes fix it with two solutions, first is verifying if PropertyWriters T parameter is the same type of parameter "value". Another that I consider more elegant is a new JsConfig that explicit say when a class needed to be treated like abstract class

*Tests was created