### PR TITLE
Update string serialize with special chars.

### DIFF
--- a/src/ServiceStack.Text/Json/JsonUtils.cs
+++ b/src/ServiceStack.Text/Json/JsonUtils.cs
@@ -11,6 +11,13 @@ namespace ServiceStack.Text.Json
         public const long MinInteger = -9007199254740992;
 
         public const char EscapeChar = '\\';
+
+        public const char EscapeTab = 't';
+        public const char EscapeCarriageReturn = 'r';
+        public const char EscapeLineFeedChar = 'n';
+        public const char EscapeFormFeedChar = 'f';
+        public const char EscapeBackspaceChar = 'b';
+
         public const char QuoteChar = '"';
         public const string Null = "null";
         public const string True = "true";
@@ -26,11 +33,11 @@ namespace ServiceStack.Text.Json
         /// Micro-optimization keep pre-built char arrays saving a .ToCharArray() + function call (see .net implementation of .Write(string))
         /// </summary>
         private static readonly char[] EscapedBackslash = { EscapeChar, EscapeChar };
-        private static readonly char[] EscapedTab = { EscapeChar, TabChar };
-        private static readonly char[] EscapedCarriageReturn = { EscapeChar, CarriageReturnChar };
-        private static readonly char[] EscapedLineFeed = { EscapeChar, LineFeedChar };
-        private static readonly char[] EscapedFormFeed = { EscapeChar, FormFeedChar };
-        private static readonly char[] EscapedBackspace = { EscapeChar, BackspaceChar };
+        private static readonly char[] EscapedTab = { EscapeChar, EscapeTab };
+        private static readonly char[] EscapedCarriageReturn = { EscapeChar, EscapeCarriageReturn };
+        private static readonly char[] EscapedLineFeed = { EscapeChar, EscapeLineFeedChar };
+        private static readonly char[] EscapedFormFeed = { EscapeChar, EscapeFormFeedChar };
+        private static readonly char[] EscapedBackspace = { EscapeChar, EscapeBackspaceChar };
         private static readonly char[] EscapedQuote = { EscapeChar, QuoteChar };
 
         public static readonly char[] WhiteSpaceChars = { ' ', TabChar, CarriageReturnChar, LineFeedChar };

--- a/tests/ServiceStack.Text.Tests/JsonTests/EscapedCharsTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/EscapedCharsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using ServiceStack.Common.Tests.Models;
 
@@ -258,6 +259,50 @@ namespace ServiceStack.Text.Tests.JsonTests
             var json = JsonSerializer.SerializeToString(array);
             Assert.That(json, Is.EqualTo(@"[""\u0018"",""Ω""]"));
         }
+
+
+        [Test]
+        public void Can_serialize_windows_new_line()
+        {
+            const string expected = "\"Hi I\'m\\r\\nnew line :)\"";
+            var text = "Hi I\'m" + Environment.NewLine + "new line :)";
+
+            var result = JsonSerializer.SerializeToString(text);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Can_serialize_object_with_escaped_chars()
+        {
+            const string expected = "{\"Id\":1,\"Name\":\"Hi I'm\\r\\nnew line :)\"}";
+            var model = new ModelWithIdAndName
+            {
+                Id = 1,
+                Name = "Hi I'm" + Environment.NewLine + "new line :)"
+            };
+
+            var result = JsonSerializer.SerializeToString(model);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void Can_deserialize_with_new_line()
+        {
+            var model = new ModelWithIdAndName
+            {
+                Id = 1,
+                Name = "Hi I'm" + Environment.NewLine + "new line :)"
+            };
+
+            const string json = "{\"Id\":1,\"Name\":\"Hi I'm\\r\\nnew line :)\"}";
+
+            var fromJson = JsonSerializer.DeserializeFromString<ModelWithIdAndName>(json);
+
+            Assert.That(fromJson, Is.EqualTo(model));
+        }
+
 
         public class MyModel
         {


### PR DESCRIPTION
When deserializing this: "Hi I'm \r\n new line :)" produces:
"Hi I'm\
\
new line :)"

This occurs because a bug in JsonUtils.WriteString, on Escaped variables it's concating EscapedChar with the '\r', '\n', '\t'... Like this: { EscapeChar, CarriageReturnChar }, produces that bug.

SS:
![image](https://cloud.githubusercontent.com/assets/7241156/7703885/3bc52282-fe11-11e4-916a-a7dffb25b273.png)

