### PR TITLE
json array containing nulls deserialization bug

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeListWithElements.cs
+++ b/src/ServiceStack.Text/Common/DeserializeListWithElements.cs
@@ -141,7 +141,14 @@ namespace ServiceStack.Text.Common
                     do
                     {
                         var itemValue = Serializer.EatTypeValue(value, ref i);
-                        to.Add((T)parseFn(itemValue));
+                        if (itemValue != null)
+                        {
+                            to.Add((T)parseFn(itemValue));
+                        }
+                        else
+                        {
+                            to.Add(default(T));
+                        }                        
                         Serializer.EatWhitespace(value, ref i);
                     } while (++i < value.Length);
                 }

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonArrayObjectTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonArrayObjectTests.cs
@@ -69,5 +69,30 @@ namespace ServiceStack.Text.Tests.JsonTests
             var oPretty = prettyJson.FromJson<NamesTest>();
             Assert.That(oPretty.Names.Count, Is.EqualTo(0));
         }
+
+        public class MyClass
+        {
+            public string Item { get; set; }
+        }
+
+        [Test]
+        public void Can_parse_array_with_null_objects_starting_with_not_null_item()
+        {
+            var compactJson = @"{""items"":[{""Item"":""myitem""},null]}";
+            var json = JsonObject.Parse(compactJson);
+            var items = json.ArrayObjects("items");
+            Assert.NotNull(items[0]);
+            Assert.Null(items[1]);
+        }
+
+        [Test]
+        public void Can_parse_array_with_null_objects_starting_with_null_item()
+        {
+            var compactJson = @"{""items"":[null,{""Item"":""myitem""}]}";
+            var json = JsonObject.Parse(compactJson);
+            var items = json.ArrayObjects("items");
+            Assert.Null(items[0]);
+            Assert.NotNull(items[1]);
+        }
     }
 }


### PR DESCRIPTION
Allowing deserialization of object arrays when some of the objects are null but the first one is not null.


This worked:

```
{
    "items": [
        null,
        {
            "Item": "myitem"
        }       
    ]
}

```

This threw a null reference exception

```
{
    "items": [
        {
            "Item": "myitem"
        },
        null
    ]
}

```

