### PR TITLE
Dictionary should not skip null values even if null values should not be serialized

### DIFF
--- a/src/ServiceStack.Text/Common/ITypeSerializer.cs
+++ b/src/ServiceStack.Text/Common/ITypeSerializer.cs
@@ -7,6 +7,8 @@ namespace ServiceStack.Text.Common
     internal interface ITypeSerializer
     {
         bool IncludeNullValues { get; }
+        bool IncludeNullValuesInDictionaries { get; }
+
         string TypeAttrInObject { get; }
 
         WriteObjectDelegate GetWriteFn<T>();

--- a/src/ServiceStack.Text/Common/WriteDictionary.cs
+++ b/src/ServiceStack.Text/Common/WriteDictionary.cs
@@ -110,7 +110,7 @@ namespace ServiceStack.Text.Common
                 var dictionaryValue = map[key];
 
                 var isNull = (dictionaryValue == null);
-                if (isNull && !Serializer.IncludeNullValues) continue;
+                if (isNull && !Serializer.IncludeNullValuesInDictionaries) continue;
 
                 var keyType = key.GetType();
                 if (writeKeyFn == null || lastKeyType != keyType)
@@ -216,7 +216,7 @@ namespace ServiceStack.Text.Common
             foreach (var kvp in map)
             {
                 var isNull = (kvp.Value == null);
-                if (isNull && !Serializer.IncludeNullValues) continue;
+                if (isNull && !Serializer.IncludeNullValuesInDictionaries) continue;
 
                 JsWriter.WriteItemSeperatorIfRanOnce(writer, ref ranOnce);
 

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -142,6 +142,21 @@ namespace ServiceStack.Text
             }
         }
 
+        private static bool? sIncludeNullValuesInDictionaries;
+        public static bool IncludeNullValuesInDictionaries
+        {
+            get
+            {
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.IncludeNullValuesInDictionaries : null)
+                    ?? sIncludeNullValuesInDictionaries
+                    ?? false;
+            }
+            set
+            {
+                if (!sIncludeNullValuesInDictionaries.HasValue) sIncludeNullValues = value;
+            }
+        }
+
         private static bool? sTreatEnumAsInteger;
         public static bool TreatEnumAsInteger
         {

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -60,6 +60,7 @@ namespace ServiceStack.Text
         public bool? TryToParsePrimitiveTypeValues { get; set; }
 		public bool? TryToParseNumericType { get; set; }
         public bool? IncludeNullValues { get; set; }
+        public bool? IncludeNullValuesInDictionaries { get; set; }
         public bool? TreatEnumAsInteger { get; set; }
         public bool? ExcludeTypeInfo { get; set; }
         public bool? IncludeTypeInfo { get; set; }

--- a/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
+++ b/src/ServiceStack.Text/Json/JsonTypeSerializer.cs
@@ -28,6 +28,11 @@ namespace ServiceStack.Text.Json
             get { return JsConfig.IncludeNullValues; }
         }
 
+        public bool IncludeNullValuesInDictionaries
+        {
+            get { return JsConfig.IncludeNullValues; }
+        }
+
         public string TypeAttrInObject
         {
             get { return JsConfig.JsonTypeAttrInObject; }

--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -28,6 +28,11 @@ namespace ServiceStack.Text.Jsv
             get { return false; } //Doesn't support null values, treated as "null" string literal
 	    }
 
+        public bool IncludeNullValuesInDictionaries
+	    {
+            get { return false; } //Doesn't support null values, treated as "null" string literal
+	    }
+
         public string TypeAttrInObject
         {
             get { return JsConfig.JsvTypeAttrInObject; }

--- a/tests/ServiceStack.Text.Tests/DictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/DictionaryTests.cs
@@ -376,7 +376,9 @@ namespace ServiceStack.Text.Tests
 		[Test]
 		public void Can_serialise_null_values_from_dictionary_correctly()
 		{
-			JsConfig.IncludeNullValues = true;
+			JsConfig.IncludeNullValues = false;
+            JsConfig.IncludeNullValuesInDictionaries = true;
+
 			var dictionary = new Dictionary<string, object> { { "value", null } };
 
 			Serialize(dictionary, includeXml: false);
@@ -391,7 +393,9 @@ namespace ServiceStack.Text.Tests
 		[Test]
 		public void Will_ignore_null_values_from_dictionary_correctly()
 		{
-			JsConfig.IncludeNullValues = false;
+			JsConfig.IncludeNullValues = true;
+			JsConfig.IncludeNullValuesInDictionaries = false;
+
 			var dictionary = new Dictionary<string, string> { { "value", null } };
 
 			Serialize(dictionary, includeXml: false);


### PR DESCRIPTION
This is IMHO defect in JSON serialization since it actually skips null values.

There is a functional difference if you skip a null value for a property since that can be restored during the deserialization easily.

But if you ommit the key-value pair during the serialization the value is lost.

I am keeping the ability to skip null vaues in dictionaries though.
