### PR TITLE
Introduce HandleGuidsAsStrings option

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -122,8 +122,11 @@ namespace ServiceStack.Text.Common
         {
             if (string.IsNullOrEmpty(value)) return null;
 
-            Guid guidValue;
-            if (Guid.TryParse(value, out guidValue)) return guidValue;
+            if ( !JsConfig.HandleGuidsAsStrings )
+            {
+                Guid guidValue;
+                if ( Guid.TryParse(value, out guidValue) ) return guidValue;
+            }
 
             if (value.StartsWith(DateTimeSerializer.EscapedWcfJsonPrefix, StringComparison.Ordinal) || value.StartsWith(DateTimeSerializer.WcfJsonPrefix, StringComparison.Ordinal))
             {

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -54,6 +54,7 @@ namespace ServiceStack.Text
             bool? assumeUtc = null,
             bool? appendUtcOffset = null,
             bool? escapeUnicode = null,
+            bool? handleGuidsAsStrings = null,
             bool? includePublicFields = null,
             bool? reuseStringBuffer = null,
             int? maxDepth = null,
@@ -90,6 +91,7 @@ namespace ServiceStack.Text
                 AssumeUtc = assumeUtc ?? sAssumeUtc,
                 AppendUtcOffset = appendUtcOffset ?? sAppendUtcOffset,
                 EscapeUnicode = escapeUnicode ?? sEscapeUnicode,
+                HandleGuidsAsStrings = handleGuidsAsStrings ?? sHandleGuidsAsStrings,
                 IncludePublicFields = includePublicFields ?? sIncludePublicFields,
                 ReuseStringBuffer = reuseStringBuffer ?? sReuseStringBuffer,
                 MaxDepth = maxDepth ?? sMaxDepth,
@@ -550,6 +552,22 @@ namespace ServiceStack.Text
             }
         }
 
+        private static bool? sHandleGuidsAsStrings;
+        public static bool HandleGuidsAsStrings
+        {
+            // obeying the use of ThreadStatic, but allowing for setting JsConfig once as is the normal case
+            get
+            {
+                return ( JsConfigScope.Current != null ? JsConfigScope.Current.HandleGuidsAsStrings : null )
+                    ?? sHandleGuidsAsStrings
+                    ?? false;
+            }
+            set
+            {
+                if ( !sHandleGuidsAsStrings.HasValue ) sHandleGuidsAsStrings = value;
+            }
+        }
+
         /// <summary>
         /// Gets or sets a value indicating if the framework should call an error handler when
         /// an exception happens during the deserialization.
@@ -743,6 +761,7 @@ namespace ServiceStack.Text
             sAssumeUtc = null;
             sAppendUtcOffset = null;
             sEscapeUnicode = null;
+            sHandleGuidsAsStrings = null;
             sOnDeserializationError = null;
             sIncludePublicFields = null;
             sReuseStringBuffer = null;

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -80,6 +80,7 @@ namespace ServiceStack.Text
         public bool? AssumeUtc { get; set; }
         public bool? AppendUtcOffset { get; set; }
         public bool? EscapeUnicode { get; set; }
+        public bool? HandleGuidsAsStrings { get; set; }
         public bool? PreferInterfaces { get; set; }
         public bool? IncludePublicFields { get; set; }
         public bool? ReuseStringBuffer { get; set; }

--- a/tests/ServiceStack.Text.Tests/DictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/DictionaryTests.cs
@@ -623,6 +623,31 @@ namespace ServiceStack.Text.Tests
             Assert.That(json.StartsWith("{"));
         }
 
+        [Test]
+        public void Do_not_lower_case_Guids()
+        {
+            JsConfig.DateHandler = DateHandler.ISO8601;
+            JsConfig.AlwaysUseUtc = true;
+            JsConfig.TryToParsePrimitiveTypeValues = true;  // needed for datetime
+
+            var original = new Dictionary<string, object>
+               {
+                   {"GuidString", "6A3F0923-A4B8-4026-9982-5C79128EA128"},
+                   {"DateTime", DateTime.UtcNow}
+               };
+
+            var json = JsonSerializer.SerializeToString(original);
+
+            json.Print();
+
+            var deserialized = JsonSerializer.DeserializeFromString<Dictionary<string, object>>(json);
+
+            Assert.That(deserialized["GuidString"], Is.EqualTo("6A3F0923-A4B8-4026-9982-5C79128EA128"));
+            Assert.That(deserialized["DateTime"], Is.AssignableTo(typeof(DateTime)));
+
+            JsConfig.Reset();
+        }
+
         private class ModelWithDictionary
         {
             public Dictionary<string, string> Value { get; set; }

--- a/tests/ServiceStack.Text.Tests/DictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/DictionaryTests.cs
@@ -629,6 +629,7 @@ namespace ServiceStack.Text.Tests
             JsConfig.DateHandler = DateHandler.ISO8601;
             JsConfig.AlwaysUseUtc = true;
             JsConfig.TryToParsePrimitiveTypeValues = true;  // needed for datetime
+            JsConfig.HandleGuidsAsStrings = true;
 
             var original = new Dictionary<string, object>
                {


### PR DESCRIPTION
This option prevents the conversion of Guid formatted strings into the Guid type. This allows Guid strings to be used as case-sensitive keys.