### PR TITLE
Make char deserialization thread-safe

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
+++ b/src/ServiceStack.Text/Common/DeserializeBuiltin.cs
@@ -70,8 +70,11 @@ namespace ServiceStack.Text.Common
                     case TypeCode.DateTime:
                         return value => DateTimeSerializer.ParseShortestXsdDateTime(value);
                     case TypeCode.Char:
-                        char cValue;
-                        return value => char.TryParse(value, out cValue) ? cValue : '\0';
+                        return value =>
+                        {
+                            char cValue;
+                            return char.TryParse(value, out cValue) ? cValue : '\0';
+                        };
                 }
 
                 if (typeof(T) == typeof(Guid))
@@ -120,8 +123,11 @@ namespace ServiceStack.Text.Common
                     case TypeCode.DateTime:
                         return value => DateTimeSerializer.ParseShortestNullableXsdDateTime(value);
                     case TypeCode.Char:
-                        char cValue;
-                        return value => string.IsNullOrEmpty(value) ? (char?)null : char.TryParse(value, out cValue) ? cValue : '\0';
+                            return value =>
+                            {
+                                char cValue;
+                                return string.IsNullOrEmpty(value) ? (char?)null : char.TryParse(value, out cValue) ? cValue : '\0';
+                            };
                 }
 
                 if (typeof(T) == typeof(TimeSpan?))


### PR DESCRIPTION
Currently, when the built-in parse function for chars is created, the temporary variable used to store the parse results becomes effectively static due to it being enclosed in a lambda.

Because it is written to then read in a non-atomic way, this creates a race condition which can lead to nasty and hard-to-track bugs when doing concurrent deserializations.

These changes make sure a new local variable is used everytime the parse function is called.