### PR TITLE
Allow inspection of request body when mocking HTTP requests

### DIFF
--- a/src/ServiceStack.Text/HttpUtils.cs
+++ b/src/ServiceStack.Text/HttpUtils.cs
@@ -431,7 +431,7 @@ namespace ServiceStack
 
             if (ResultsFilter != null)
             {
-                return ResultsFilter.GetString(webReq);
+                return ResultsFilter.GetString(webReq, requestBody);
             }
 
             if (requestBody != null)
@@ -498,7 +498,7 @@ namespace ServiceStack
 
             if (ResultsFilter != null)
             {
-                return ResultsFilter.GetBytes(webReq);
+                return ResultsFilter.GetBytes(webReq, requestBody);
             }
 
             if (requestBody != null)
@@ -803,8 +803,8 @@ namespace ServiceStack
 
     public interface IHttpResultsFilter : IDisposable
     {
-        string GetString(HttpWebRequest webReq);
-        byte[] GetBytes(HttpWebRequest webReq);
+        string GetString(HttpWebRequest webReq, string reqBody);
+        byte[] GetBytes(HttpWebRequest webReq, byte[] reqBody);
         void UploadStream(HttpWebRequest webRequest, Stream fileStream, string fileName);
     }
 
@@ -815,8 +815,8 @@ namespace ServiceStack
         public string StringResult { get; set; }
         public byte[] BytesResult { get; set; }
 
-        public Func<HttpWebRequest, string> StringResultFn { get; set; }
-        public Func<HttpWebRequest, byte[]> BytesResultFn { get; set; }
+        public Func<HttpWebRequest, string, string> StringResultFn { get; set; }
+        public Func<HttpWebRequest, byte[], byte[]> BytesResultFn { get; set; }
         public Action<HttpWebRequest, Stream, string> UploadFileFn { get; set; }
 
         public HttpResultsFilter(string stringResult=null, byte[] bytesResult=null)
@@ -833,17 +833,17 @@ namespace ServiceStack
             HttpUtils.ResultsFilter = previousFilter;
         }
 
-        public string GetString(HttpWebRequest webReq)
+        public string GetString(HttpWebRequest webReq, string reqBody)
         {
             return StringResultFn != null
-                ? StringResultFn(webReq)
+                ? StringResultFn(webReq, reqBody)
                 : StringResult;
         }
 
-        public byte[] GetBytes(HttpWebRequest webReq)
+        public byte[] GetBytes(HttpWebRequest webReq, byte[] reqBody)
         {
             return BytesResultFn != null
-                ? BytesResultFn(webReq)
+                ? BytesResultFn(webReq, reqBody)
                 : BytesResult;
         }
 

--- a/tests/ServiceStack.Text.Tests/HttpUtilsMockTests.cs
+++ b/tests/ServiceStack.Text.Tests/HttpUtilsMockTests.cs
@@ -82,9 +82,14 @@ namespace ServiceStack.Text.Tests
         {
             using (new HttpResultsFilter
             {
-                StringResultFn = webReq => webReq.RequestUri.ToString().Contains("google")
-                    ? "mocked-google"
-                    : "mocked-yahoo"
+                StringResultFn = (webReq, reqBody) =>
+                {
+                    if (reqBody != null && reqBody.Contains("{\"a\":1}")) return "mocked-by-body";
+
+                    return webReq.RequestUri.ToString().Contains("google")
+                        ? "mocked-google"
+                        : "mocked-yahoo";
+                }
             })
             {
                 Assert.That(ExampleGoogleUrl.GetJsonFromUrl(), Is.EqualTo("mocked-google"));
@@ -92,6 +97,8 @@ namespace ServiceStack.Text.Tests
 
                 Assert.That(ExampleGoogleUrl.PostJsonToUrl(json: "{\"postdata\":1}"), Is.EqualTo("mocked-google"));
                 Assert.That(ExampleYahooUrl.PostJsonToUrl(json: "{\"postdata\":1}"), Is.EqualTo("mocked-yahoo"));
+
+                Assert.That(ExampleYahooUrl.PostJsonToUrl(json: "{\"a\":1}"), Is.EqualTo("mocked-by-body"));
             }
         }
 
@@ -100,9 +107,14 @@ namespace ServiceStack.Text.Tests
         {
             using (new HttpResultsFilter
             {
-                BytesResultFn = webReq => webReq.RequestUri.ToString().Contains("google")
-                    ? "mocked-google".ToUtf8Bytes()
-                    : "mocked-yahoo".ToUtf8Bytes()
+                BytesResultFn = (webReq, reqBody) =>
+                {
+                    if (reqBody != null && reqBody.FromUtf8Bytes().Contains("{\"a\":1}")) return "mocked-by-body".ToUtf8Bytes();
+
+                    return webReq.RequestUri.ToString().Contains("google")
+                        ? "mocked-google".ToUtf8Bytes()
+                        : "mocked-yahoo".ToUtf8Bytes();
+                }
             })
             {
                 Assert.That(ExampleGoogleUrl.GetBytesFromUrl(), Is.EqualTo("mocked-google".ToUtf8Bytes()));
@@ -110,6 +122,8 @@ namespace ServiceStack.Text.Tests
 
                 Assert.That(ExampleGoogleUrl.PostBytesToUrl(requestBody: "postdata=1".ToUtf8Bytes()), Is.EqualTo("mocked-google".ToUtf8Bytes()));
                 Assert.That(ExampleYahooUrl.PostBytesToUrl(requestBody: "postdata=1".ToUtf8Bytes()), Is.EqualTo("mocked-yahoo".ToUtf8Bytes()));
+
+                Assert.That(ExampleYahooUrl.PostBytesToUrl(requestBody: "{\"a\":1}".ToUtf8Bytes()), Is.EqualTo("mocked-by-body".ToUtf8Bytes()));
             }
         }
 


### PR DESCRIPTION
It was not possible to inspect the request body when mocking HTTP requests. As discussed here: http://stackoverflow.com/questions/31630526/can-i-test-form-data-using-httpresultsfilter-callback

This pull request fixes this. However, it does introduce breaking changes so I figure you may not wish to merge it as is.
