### PR TITLE
FixXsdTimeSpanDeserialize

### DIFF
--- a/src/ServiceStack.Text/Support/TimeSpanConverter.cs
+++ b/src/ServiceStack.Text/Support/TimeSpanConverter.cs
@@ -56,7 +56,13 @@ namespace ServiceStack.Text.Support
             int hours = 0;
             int minutes = 0;
             double seconds = 0;
-            var sign = (xsdDuration.StartsWith("-", StringComparison.Ordinal) ? -1 : 1);
+            int sign = 1;
+
+            if (xsdDuration.StartsWith("-", StringComparison.Ordinal))
+            {
+                sign = -1;
+                xsdDuration = xsdDuration.Substring(1); //strip sign
+            }
 
             string[] t = xsdDuration.Substring(1).SplitOnFirst('T'); //strip P
 

--- a/tests/ServiceStack.Text.Tests/DateTimeOffsetAndTimeSpanTests.cs
+++ b/tests/ServiceStack.Text.Tests/DateTimeOffsetAndTimeSpanTests.cs
@@ -60,26 +60,6 @@ namespace ServiceStack.Text.Tests
         }
 
         [Test]
-        public void Can_serialize_negative_TimeSpan_field()
-        {
-            var period = new TimeSpan(0, 0, -15, 0);
-
-            var model = new SampleModel { Id = 1, TimeSpan = period };
-            var json = JsonSerializer.SerializeToString(model);
-            Assert.That(json, Is.StringContaining("\"TimeSpan\":\"-PT15M\""));
-        }
-
-        [Test]
-        public void Can_deserialize_negative_TimeSpan_string()
-        {
-            var expectedTimeSpan = new TimeSpan(0, 0, -15, 0);
-            const string timeSpanString = @"-PT15M";
-
-            var timeSpan = JsonSerializer.DeserializeFromString<TimeSpan>(timeSpanString);
-            Assert.That(timeSpan, Is.EqualTo(expectedTimeSpan));
-        }
-
-        [Test]
         public void Can_serialize_TimeSpan_field_with_StandardTimeSpanFormat()
         {
             using (JsConfig.With(timeSpanHandler:TimeSpanHandler.StandardFormat))

--- a/tests/ServiceStack.Text.Tests/TimeSpanConverterTests.cs
+++ b/tests/ServiceStack.Text.Tests/TimeSpanConverterTests.cs
@@ -7,34 +7,69 @@ namespace ServiceStack.Text.Tests
     [TestFixture]
     public class TimeSpanConverterTests
     {
+        private readonly TimeSpan oneTick = new TimeSpan(1);
+        private readonly TimeSpan oneDay = new TimeSpan(1, 0, 0, 0);
+        private readonly TimeSpan oneHour = new TimeSpan(1, 0, 0);
+        private readonly TimeSpan oneMinute = new TimeSpan(0, 1, 0);
+        private readonly TimeSpan oneSecond = new TimeSpan(0, 0, 1);
+        private readonly TimeSpan oneMilliSecond = new TimeSpan(0, 0, 0, 0, 1);
+        private readonly TimeSpan oneDayHourMinuteSecondMilliSecond = new TimeSpan(1, 1, 1, 1, 1);
+        private readonly TimeSpan threeThousandSixHundredAndFiveDays = TimeSpan.FromDays(3605);
+        private readonly TimeSpan arbitraryTimeSpan = new TimeSpan(1, 2, 3, 4, 567).Add(TimeSpan.FromTicks(1));
+
         [Test]
         public void Can_Serialize_TimeSpan()
         {
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(1, 0, 0, 0)), Is.EqualTo("P1D"));
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(1, 0, 0)), Is.EqualTo("PT1H"));
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(0, 1, 0)), Is.EqualTo("PT1M"));
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(0, 0, 1)), Is.EqualTo("PT1S"));
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(0, 0, 0, 0, 1)), Is.EqualTo("PT0.001S"));
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(1, 1, 1, 1, 1)), Is.EqualTo("P1DT1H1M1.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneDay), Is.EqualTo("P1D"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneHour), Is.EqualTo("PT1H"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneMinute), Is.EqualTo("PT1M"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneSecond), Is.EqualTo("PT1S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneMilliSecond), Is.EqualTo("PT0.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneDayHourMinuteSecondMilliSecond), Is.EqualTo("P1DT1H1M1.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(arbitraryTimeSpan), Is.EqualTo("P1DT2H3M4.5670001S"));
 
-            Assert.That(TimeSpanConverter.ToXsdDuration(new TimeSpan(1)), Is.EqualTo("PT0.0000001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneDay), Is.EqualTo("-P1D"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneHour), Is.EqualTo("-PT1H"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneMinute), Is.EqualTo("-PT1M"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneSecond), Is.EqualTo("-PT1S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneMilliSecond), Is.EqualTo("-PT0.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-arbitraryTimeSpan), Is.EqualTo("-P1DT2H3M4.5670001S"));
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneTick), Is.EqualTo("PT0.0000001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneTick), Is.EqualTo("-PT0.0000001S"));
+
             Assert.That(TimeSpanConverter.ToXsdDuration(TimeSpan.Zero), Is.EqualTo("PT0S"));
-            Assert.That(TimeSpanConverter.ToXsdDuration(new DateTime(2010,1,1) - new DateTime(2000,1,1)), Is.EqualTo("P3653D"));
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(threeThousandSixHundredAndFiveDays), Is.EqualTo("P3605D"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-threeThousandSixHundredAndFiveDays), Is.EqualTo("-P3605D"));
         }
 
         [Test]
         public void Can_deserialize_TimeSpan()
         {
-            Assert.That(TimeSpanConverter.FromXsdDuration("P1D"), Is.EqualTo(new TimeSpan(1, 0, 0, 0)));
-            Assert.That(TimeSpanConverter.FromXsdDuration("PT1H"), Is.EqualTo(new TimeSpan(1, 0, 0)));
-            Assert.That(TimeSpanConverter.FromXsdDuration("PT1M"), Is.EqualTo(new TimeSpan(0, 1, 0)));
-            Assert.That(TimeSpanConverter.FromXsdDuration("PT1S"), Is.EqualTo(new TimeSpan(0, 0, 1)));
-            Assert.That(TimeSpanConverter.FromXsdDuration("PT0.001S"), Is.EqualTo(new TimeSpan(0, 0, 0, 0, 1)));
-            Assert.That(TimeSpanConverter.FromXsdDuration("P1DT1H1M1.001S"), Is.EqualTo(new TimeSpan(1, 1, 1, 1, 1)));
+            Assert.That(TimeSpanConverter.FromXsdDuration("P1D"), Is.EqualTo(oneDay));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT1H"), Is.EqualTo(oneHour));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT1M"), Is.EqualTo(oneMinute));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT1S"), Is.EqualTo(oneSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT0.001S"), Is.EqualTo(oneMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("P1DT1H1M1.001S"), Is.EqualTo(oneDayHourMinuteSecondMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("P1DT2H3M4.5670001S"), Is.EqualTo(arbitraryTimeSpan));
 
-            Assert.That(TimeSpanConverter.FromXsdDuration("PT0.0000001S"), Is.EqualTo(new TimeSpan(1)));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P1D"), Is.EqualTo(-oneDay));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT1H"), Is.EqualTo(-oneHour));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT1M"), Is.EqualTo(-oneMinute));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT1S"), Is.EqualTo(-oneSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT0.001S"), Is.EqualTo(-oneMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P1DT1H1M1.001S"), Is.EqualTo(-oneDayHourMinuteSecondMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P1DT2H3M4.5670001S"), Is.EqualTo(-arbitraryTimeSpan));
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT0.0000001S"), Is.EqualTo(oneTick));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT0.0000001S"), Is.EqualTo(-oneTick));
+
             Assert.That(TimeSpanConverter.FromXsdDuration("PT0S"), Is.EqualTo(TimeSpan.Zero));
-            Assert.That(TimeSpanConverter.FromXsdDuration("P3650D"), Is.EqualTo(TimeSpan.FromDays(3650)));
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("P3605D"), Is.EqualTo(threeThousandSixHundredAndFiveDays));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P3605D"), Is.EqualTo(-threeThousandSixHundredAndFiveDays));
         }
     }
 }


### PR DESCRIPTION
one more fix to deserialization of negative timespan
moved unit tests added in previous pr to TimeSpanConvertTests, and added more tests there