### PR TITLE
Fix FormatException thrown in Env static constructor

### DIFF
--- a/src/ServiceStack.Text/Env.cs
+++ b/src/ServiceStack.Text/Env.cs
@@ -2,6 +2,7 @@
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt
 
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace ServiceStack.Text
@@ -47,9 +48,9 @@ namespace ServiceStack.Text
                 + platformName
                 + (IsMono ? "/Mono" : "/.NET");
 
-            VersionString = ServiceStackVersion.ToString();
+            VersionString = ServiceStackVersion.ToString(CultureInfo.InvariantCulture);
 
-            __releaseDate = DateTime.Parse("2001-01-01");
+            __releaseDate = DateTime.Parse("2001-01-01", CultureInfo.InvariantCulture);
         }
 
         public static string VersionString { get; set; }


### PR DESCRIPTION
The sample below demonstrates this bug. I'm not sure how to add a test for this to the test suite because the bug is in a static constructor, and therefore the testcase would need to always be the first one to run in the test suite.

```csharp
using System.Globalization;
using System.Threading;
using ServiceStack; // Version 4.0.50

namespace TestCase
{
    class Program
    {
        static void Main(string[] args)
        {
            Thread.CurrentThread.CurrentCulture = new CultureInfo("ar");
            JsonServiceClient client = new JsonServiceClient();
        }
    }
}
```

### Output

```
Unhandled Exception: System.TypeInitializationException: The type initializer for  'ServiceStack.ServiceClientBase' threw
 an exception. ---> System.TypeInitializationException: The type initializer for 'ServiceStack.Text.Env' threw an except
ion. ---> System.FormatException: String was not recognized as a valid DateTime.
   at System.DateTimeParse.Parse(String s, DateTimeFormatInfo dtfi, DateTimeStyles styles)
   at System.DateTime.Parse(String s)
   at ServiceStack.Text.Env..cctor()
   --- End of inner exception stack trace ---
   at ServiceStack.ServiceClientBase..cctor()
   --- End of inner exception stack trace ---
   at ServiceStack.ServiceClientBase..ctor()
   at ServiceStack.JsonServiceClient..ctor()
   at TestCase.Program.Main(String[] args) in D:\Projects\SSTest
Case\Program.cs:line 12
```