### PR TITLE
Fix serialization bug in DateHandler.ISO8601DateTime (hh => HH)

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -601,7 +601,7 @@ namespace ServiceStack.Text.Common
             }
             if (JsConfig.DateHandler == DateHandler.ISO8601DateTime)
             {
-                writer.Write(dateTime.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture));
+                writer.Write(dateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
                 return;
             }
             if (JsConfig.DateHandler == DateHandler.RFC1123)


### PR DESCRIPTION
Serialization of DateTime using `DateHandler.ISO8601DateTime` incorrectly uses [hh](https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx#Anchor_20) instead of [HH](https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx#Anchor_22) which means hours in the PM would silently get converted to AM hours(!). In other words, no matter what you feed it, you'd always get an hour between 00 to 12 instead of 00 to 23.

PS as a side note, not sure a space is a valid character in ISO8601 representation between the date and the time (this should be a 'T') so I'm not sure about calling this ISO8601. It looks more like a MySQL DATETIME format.