### PR TITLE
fix handling urls endwith "&" or "?"

### DIFF
--- a/src/ServiceStack.Text/HttpUtils.cs
+++ b/src/ServiceStack.Text/HttpUtils.cs
@@ -29,7 +29,11 @@ namespace ServiceStack
         public static string AddQueryParam(this string url, string key, string val, bool encode = true)
         {
             if (string.IsNullOrEmpty(url)) return null;
-            var prefix = url.IndexOf('?') == -1 ? "?" : "&";
+            var prefix = string.Empty;
+            if (!url.EndsWith("?") && !url.EndsWith("&"))
+            {
+                prefix = url.IndexOf('?') == -1 ? "?" : "&";
+            }
             return url + prefix + key + "=" + (encode ? val.UrlEncode() : val);
         }
 

--- a/tests/ServiceStack.Text.Tests/HttpUtilsTests.cs
+++ b/tests/ServiceStack.Text.Tests/HttpUtilsTests.cs
@@ -13,6 +13,8 @@ namespace ServiceStack.Text.Tests
             Assert.That("http://example.com?f=1".AddQueryParam("f", "2"), Is.EqualTo("http://example.com?f=1&f=2"));
             Assert.That("http://example.com?s=0&f=1&s=1".AddQueryParam("f", "2"), Is.EqualTo("http://example.com?s=0&f=1&s=1&f=2"));
             Assert.That("http://example.com?s=rf&f=1".AddQueryParam("f", "2"), Is.EqualTo("http://example.com?s=rf&f=1&f=2"));
+            Assert.That("http://example.com?".AddQueryParam("f", "1"), Is.EqualTo("http://example.com?f=1"));
+            Assert.That("http://example.com?f=1&".AddQueryParam("f", "2"), Is.EqualTo("http://example.com?f=1&f=2"));
         }
 
         [Test]


### PR DESCRIPTION
before:
"http://example.com?".AddQueryParam("f", "1")  => "http://example.com?&f=1"
"http://example.com?f=1&".AddQueryParam("f", "2") => "http://example.com?f=1&&f=2"

after:
"http://example.com?".AddQueryParam("f", "1")  => "http://example.com?f=1"
"http://example.com?f=1&".AddQueryParam("f", "2") => "http://example.com?f=1&f=2"