### PR TITLE
Fix CSV tests on Linux

### DIFF
--- a/src/ServiceStack.Text/CsvConfig.cs
+++ b/src/ServiceStack.Text/CsvConfig.cs
@@ -107,7 +107,7 @@ namespace ServiceStack.Text
         {
             get
             {
-                return tsRowSeparatorString ?? sRowSeparatorString ?? Environment.NewLine;
+                return tsRowSeparatorString ?? sRowSeparatorString ?? "\r\n";
             }
             set
             {

--- a/tests/ServiceStack.Text.Tests/CsvStreamTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvStreamTests.cs
@@ -66,12 +66,9 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(categories);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"Id,CategoryName,Description,Picture"
-				+ Environment.NewLine 
-				+ "1,\"between \"\"quotes\"\" here\",\"with, comma\","
-				+ Environment.NewLine
-				+ "1,\"between \"\"quotes\"\" here\",\"with, comma\","
-				+ Environment.NewLine
+				"Id,CategoryName,Description,Picture\r\n"
+				+ "1,\"between \"\"quotes\"\" here\",\"with, comma\",\r\n"
+				+ "1,\"between \"\"quotes\"\" here\",\"with, comma\",\r\n"
 			));
 		}
 
@@ -85,12 +82,9 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(categories);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"Id|CategoryName|Description|Picture"
-				+ Environment.NewLine 
-				+ "1|\"between \"\"quotes\"\" here\"|with, comma|"
-				+ Environment.NewLine
-				+ "1|\"between \"\"quotes\"\" here\"|with, comma|"
-				+ Environment.NewLine
+				"Id|CategoryName|Description|Picture\r\n"
+				+ "1|\"between \"\"quotes\"\" here\"|with, comma|\r\n"
+				+ "1|\"between \"\"quotes\"\" here\"|with, comma|\r\n"
 			));
 		}
 
@@ -104,12 +98,9 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(categories);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"Id,CategoryName,Description,Picture"
-				+ Environment.NewLine 
-				+ "1,between \"quotes\" here,|with, comma|,"
-				+ Environment.NewLine
-				+ "1,between \"quotes\" here,|with, comma|,"
-				+ Environment.NewLine
+				"Id,CategoryName,Description,Picture\r\n"
+				+ "1,between \"quotes\" here,|with, comma|,\r\n"
+				+ "1,between \"quotes\" here,|with, comma|,\r\n"
 			));
 		}
 
@@ -123,12 +114,9 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(categories);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"Id,CategoryName,Description,Picture"
-				+ Environment.NewLine 
-				+ "1,between \"quotes\" here,~^~with, comma~^~,"
-				+ Environment.NewLine
-				+ "1,between \"quotes\" here,~^~with, comma~^~,"
-				+ Environment.NewLine
+				"Id,CategoryName,Description,Picture\r\n"
+				+ "1,between \"quotes\" here,~^~with, comma~^~,\r\n"
+				+ "1,between \"quotes\" here,~^~with, comma~^~,\r\n"
 			));
 		}
 
@@ -139,8 +127,7 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(fields);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"1,2,\"3\"\"\",4,\"5\"\"five,six\"\"\",\"7,7.1\",\"\"\"7,7.1\"\"\",8"
-				+ Environment.NewLine
+				"1,2,\"3\"\"\",4,\"5\"\"five,six\"\"\",\"7,7.1\",\"\"\"7,7.1\"\"\",8\r\n"
 			));
 		}
 
@@ -152,8 +139,7 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(fields);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"1,2,3\",4,|5\"five,six\"|,|7,7.1|,|\"7,7.1\"|,8"
-				+ Environment.NewLine
+				"1,2,3\",4,|5\"five,six\"|,|7,7.1|,|\"7,7.1\"|,8\r\n"
 			));
 		}
 
@@ -165,8 +151,7 @@ namespace ServiceStack.Text.Tests
 			var csv = CsvSerializer.SerializeToCsv(fields);
 			Log(csv);
 			Assert.That(csv, Is.EqualTo(
-				"1|2|\"3\"\"\"|4|\"5\"\"five,six\"\"\"|7,7.1|\"\"\"7,7.1\"\"\"|8"
-				+ Environment.NewLine
+				"1|2|\"3\"\"\"|4|\"5\"\"five,six\"\"\"|7,7.1|\"\"\"7,7.1\"\"\"|8\r\n"
 			));
 		}
 

--- a/tests/ServiceStack.Text.Tests/CsvTests/CustomHeaderTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/CustomHeaderTests.cs
@@ -34,12 +34,9 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column 1,Column 2,\"Column,3\",\"Column\n4\",Column 5"
-				+ Environment.NewLine
-				+ "I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
+				"Column 1,Column 2,\"Column,3\",\"Column\n4\",Column 5\r\n"
+				+ "I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
 			));
 		}
 
@@ -63,12 +60,9 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column 1,Column 2,\"Column,3\",\"Column\n4\",Column 5"
-				+ Environment.NewLine
-				+ "I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
+				"Column 1,Column 2,\"Column,3\",\"Column\n4\",Column 5\r\n"
+				+ "I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
 			));
 		}
 
@@ -90,12 +84,9 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column 1,\"Column,3\",Column 5"
-				+ Environment.NewLine
-				+ "I,To,Novels"
-				+ Environment.NewLine
-				+ "I am,Cool,Awesome"
-				+ Environment.NewLine
+				"Column 1,\"Column,3\",Column 5\r\n"
+				+ "I,To,Novels\r\n"
+				+ "I am,Cool,Awesome\r\n"
 			));
 		}
 
@@ -121,10 +112,8 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
+				"I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
 			));
 		}
 

--- a/tests/ServiceStack.Text.Tests/CsvTests/DictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/DictionaryTests.cs
@@ -24,20 +24,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data"
-				+ Environment.NewLine
-				+ ",Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,,Cool,And,Awesome"
-				+ Environment.NewLine
-				+ "I, Like ,,,"
-				+ Environment.NewLine
-				+ "I,Don't,\"Know,\",,You?"
-				+ Environment.NewLine
-				+ "I,Saw,The,Movie,"
-				+ Environment.NewLine
-				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\""
-				+ Environment.NewLine
+				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data\r\n"
+				+ ",Like,To,Read,Novels\r\n"
+				+ "I am,,Cool,And,Awesome\r\n"
+				+ "I, Like ,,,\r\n"
+				+ "I,Don't,\"Know,\",,You?\r\n"
+				+ "I,Saw,The,Movie,\r\n"
+				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\"\r\n"
 			));
 		}
 
@@ -57,20 +50,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data"
-				+ Environment.NewLine
-				+ "I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
-				+ "I, Like ,Reading,,"
-				+ Environment.NewLine
-				+ "I,Don't,\"Know,\",Do,You?"
-				+ Environment.NewLine
-				+ "I,Saw,The,Movie,\"\"\"Jaws\"\"\""
-				+ Environment.NewLine
-				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\""
-				+ Environment.NewLine
+				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data\r\n"
+				+ "I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
+				+ "I, Like ,Reading,,\r\n"
+				+ "I,Don't,\"Know,\",Do,You?\r\n"
+				+ "I,Saw,The,Movie,\"\"\"Jaws\"\"\"\r\n"
+				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\"\r\n"
 			));
 		}
 
@@ -133,20 +119,13 @@ namespace ServiceStack.Text.Tests.CsvTests
             Console.WriteLine(csv);
 
             Assert.That(csv, Is.EqualTo(
-                "Column1Data,Column2Data,Column3Data,Column4Data,Column5Data"
-                + Environment.NewLine
-                + "I,Like,To,Read,123"
-                + Environment.NewLine
-                + "I am,Very,Cool,And,4"
-                + Environment.NewLine
-                + "I, Like ,2,,"
-                + Environment.NewLine
-                + "I,Don't,\"Know,\",Do,You?"
-                + Environment.NewLine
-                + "I,Saw,The,Movie,\"\"\"Jaws\"\"\""
-                + Environment.NewLine
-                + "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\""
-                + Environment.NewLine
+				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data\r\n"
+				+ "I,Like,To,Read,123\r\n"
+				+ "I am,Very,Cool,And,4\r\n"
+				+ "I, Like ,2,,\r\n"
+				+ "I,Don't,\"Know,\",Do,You?\r\n"
+				+ "I,Saw,The,Movie,\"\"\"Jaws\"\"\"\r\n"
+				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\"\r\n"
                                  ));
         }
 
@@ -173,20 +152,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data"
-				+ Environment.NewLine
-				+ "I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
-				+ "I, Like ,Reading,,"
-				+ Environment.NewLine
-				+ "I,Don't,^~^Know,^~^,Do,You?"
-				+ Environment.NewLine
-				+ "I,Saw,The,Movie,\"Jaws\""
-				+ Environment.NewLine
-				+ "I,Went,To,^~^Space\nCamp^~^,^~^Last\r\nYear^~^"
-				+ Environment.NewLine
+				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data\r\n"
+				+ "I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
+				+ "I, Like ,Reading,,\r\n"
+				+ "I,Don't,^~^Know,^~^,Do,You?\r\n"
+				+ "I,Saw,The,Movie,\"Jaws\"\r\n"
+				+ "I,Went,To,^~^Space\nCamp^~^,^~^Last\r\nYear^~^\r\n"
 			));
 		}
 
@@ -207,20 +179,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data|Column2Data|Column3Data|Column4Data|Column5Data"
-				+ Environment.NewLine
-				+ "I|Like|To|Read|Novels"
-				+ Environment.NewLine
-				+ "I am|Very|Cool|And|Awesome"
-				+ Environment.NewLine
-				+ "I| Like |Reading||"
-				+ Environment.NewLine
-				+ "I|Don't|Know,|Do|You?"
-				+ Environment.NewLine
-				+ "I|Saw|The|Movie|\"\"\"Jaws\"\"\""
-				+ Environment.NewLine
-				+ "I|Went|To|\"Space\nCamp\"|\"Last\r\nYear\""
-				+ Environment.NewLine
+				"Column1Data|Column2Data|Column3Data|Column4Data|Column5Data\r\n"
+				+ "I|Like|To|Read|Novels\r\n"
+				+ "I am|Very|Cool|And|Awesome\r\n"
+				+ "I| Like |Reading||\r\n"
+				+ "I|Don't|Know,|Do|You?\r\n"
+				+ "I|Saw|The|Movie|\"\"\"Jaws\"\"\"\r\n"
+				+ "I|Went|To|\"Space\nCamp\"|\"Last\r\nYear\"\r\n"
 			));
 		}
 	}

--- a/tests/ServiceStack.Text.Tests/CsvTests/NewLineTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/NewLineTests.cs
@@ -24,20 +24,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data"
-				+ Environment.NewLine
-				+ "I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
-				+ "I, Like ,Reading,,"
-				+ Environment.NewLine
-				+ "I,Don't,\"Know,\",Do,You?"
-				+ Environment.NewLine
-				+ "I,Saw,The,Movie,\"\"\"Jaws\"\"\""
-				+ Environment.NewLine
-				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\""
-				+ Environment.NewLine
+				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data\r\n"
+				+ "I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
+				+ "I, Like ,Reading,,\r\n"
+				+ "I,Don't,\"Know,\",Do,You?\r\n"
+				+ "I,Saw,The,Movie,\"\"\"Jaws\"\"\"\r\n"
+				+ "I,Went,To,\"Space\nCamp\",\"Last\r\nYear\"\r\n"
 			));
 		}
         [TearDown]
@@ -63,20 +56,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data|Column2Data|Column3Data|Column4Data|Column5Data"
-				+ Environment.NewLine
-				+ "I|Like|To|Read|Novels"
-				+ Environment.NewLine
-				+ "I am|Very|Cool|And|Awesome"
-				+ Environment.NewLine
-				+ "I| Like |Reading||"
-				+ Environment.NewLine
-				+ "I|Don't|Know,|Do|You?"
-				+ Environment.NewLine
-				+ "I|Saw|The|Movie|\"\"\"Jaws\"\"\""
-				+ Environment.NewLine
-				+ "I|Went|To|\"Space\nCamp\"|\"Last\r\nYear\""
-				+ Environment.NewLine
+				"Column1Data|Column2Data|Column3Data|Column4Data|Column5Data\r\n"
+				+ "I|Like|To|Read|Novels\r\n"
+				+ "I am|Very|Cool|And|Awesome\r\n"
+				+ "I| Like |Reading||\r\n"
+				+ "I|Don't|Know,|Do|You?\r\n"
+				+ "I|Saw|The|Movie|\"\"\"Jaws\"\"\"\r\n"
+				+ "I|Went|To|\"Space\nCamp\"|\"Last\r\nYear\"\r\n"
 			));
 		}
 
@@ -97,20 +83,13 @@ namespace ServiceStack.Text.Tests.CsvTests
 			Console.WriteLine(csv);
 
 			Assert.That(csv, Is.EqualTo(
-				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data"
-				+ Environment.NewLine
-				+ "I,Like,To,Read,Novels"
-				+ Environment.NewLine
-				+ "I am,Very,Cool,And,Awesome"
-				+ Environment.NewLine
-				+ "I, Like ,Reading,,"
-				+ Environment.NewLine
-				+ "I,Don't,|Know,|,Do,You?"
-				+ Environment.NewLine
-				+ "I,Saw,The,Movie,\"Jaws\""
-				+ Environment.NewLine
-				+ "I,Went,To,|Space\nCamp|,|Last\r\nYear|"
-				+ Environment.NewLine
+				"Column1Data,Column2Data,Column3Data,Column4Data,Column5Data\r\n"
+				+ "I,Like,To,Read,Novels\r\n"
+				+ "I am,Very,Cool,And,Awesome\r\n"
+				+ "I, Like ,Reading,,\r\n"
+				+ "I,Don't,|Know,|,Do,You?\r\n"
+				+ "I,Saw,The,Movie,\"Jaws\"\r\n"
+				+ "I,Went,To,|Space\nCamp|,|Last\r\nYear|\r\n"
 			));
 		}
 	}


### PR DESCRIPTION
According to RFC 4180 https://www.ietf.org/rfc/rfc4180.txt CSV line must end with CRLF
Previous versions of CSV serializer generated CSV using Environment.NewLine
which differs on Windows/Linux/Mac platforms. This commit changes default CSV line ending to CRLF and fixes the tests for Linux/Mac platform.