### PR TITLE
Fix PCL deserializing private set property in base type

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -293,7 +293,7 @@ namespace ServiceStack.Text.Common
 
         private static SetPropertyDelegate GetSetPropertyMethod(TypeConfig typeConfig, PropertyInfo propertyInfo)
         {
-            if (propertyInfo.ReflectedType() != propertyInfo.DeclaringType)
+            if (typeConfig.Type != propertyInfo.DeclaringType)
                 propertyInfo = propertyInfo.DeclaringType.GetPropertyInfo(propertyInfo.Name);
 
             if (!propertyInfo.CanWrite && !typeConfig.EnableAnonymousFieldSetterses) return null;
@@ -345,7 +345,7 @@ namespace ServiceStack.Text.Common
 
         private static SetPropertyDelegate GetSetFieldMethod(TypeConfig typeConfig, FieldInfo fieldInfo)
         {
-            if (fieldInfo.ReflectedType() != fieldInfo.DeclaringType)
+            if (typeConfig.Type != fieldInfo.DeclaringType)
                 fieldInfo = fieldInfo.DeclaringType.GetFieldInfo(fieldInfo.Name);
 
             return PclExport.Instance.GetSetFieldMethod(fieldInfo);

--- a/tests/ServiceStack.Text.Tests/JsonTests/InheritanceTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/InheritanceTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ServiceStack.Text.Tests.JsonTests
+{
+    [TestFixture]
+    class InheritanceTest
+    {
+        public class BaseClass
+        {
+            protected string base64Value = string.Empty;
+            public string Value { get { return this.base64Value; } private set { this.base64Value = value; } }
+
+            public void Set(string val)
+            {
+                this.base64Value = val;
+            }
+        }
+
+        public class Derived : BaseClass
+        {
+        }
+
+        [Test]
+        public void Can_deserialize_private_set_in_base_class()
+        {
+            var derived = new Derived();
+            derived.Set("test");
+
+            string serialized = derived.ToJson();
+            var deserialized = serialized.FromJson<Derived>();
+
+            Assert.That(deserialized.Value, Is.EqualTo("test"));
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -193,6 +193,7 @@
     <Compile Include="HttpUtilsTests.cs" />
     <Compile Include="Issues\JsConfigIssues.cs" />
     <Compile Include="JsonTests\InheritAbstractTests.cs" />
+    <Compile Include="JsonTests\InheritanceTests.cs" />
     <Compile Include="JsonTests\JsonEnumTests.cs" />
     <Compile Include="JsonTests\InvalidJsonTests.cs" />
     <Compile Include="JsonTests\OnDeserializationErrorTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/ServiceStack/Issues/issues/451#issuecomment-230575637

extension PropertyInfo.ReflectedType() in PCL version returns `MemberInfo.DeclaringType` instead of  `MemberInfo.ReflectedType`, because `MemberInfo.ReflectedType` is not available in PCL profile. `TypeConfig` contains information about deserialized type and it's the same as `PropertyInfo.ReflectedType`. 