### PR TITLE
Add ability to set up HttpWebRequest properties

### DIFF
--- a/src/ServiceStack.Text/PclExport.Net40.cs
+++ b/src/ServiceStack.Text/PclExport.Net40.cs
@@ -545,6 +545,26 @@ namespace ServiceStack
             if (preAuthenticate.HasValue) req.PreAuthenticate = preAuthenticate.Value;
         }
 
+        public override void SetUserAgent(HttpWebRequest httpReq, string value)
+        {
+            httpReq.UserAgent = value;
+        }
+
+        public override void SetContentLength(HttpWebRequest httpReq, long value)
+        {
+            httpReq.ContentLength = value;
+        }
+
+        public override void SetAllowAutoRedirect(HttpWebRequest httpReq, bool value)
+        {
+            httpReq.AllowAutoRedirect = value;
+        }
+
+        public override void SetKeepAlive(HttpWebRequest httpReq, bool value)
+        {
+            httpReq.KeepAlive = value;
+        }
+
         public override string GetStackTrace()
         {
             return Environment.StackTrace;

--- a/src/ServiceStack.Text/PclExport.NetStandard.cs
+++ b/src/ServiceStack.Text/PclExport.NetStandard.cs
@@ -13,10 +13,10 @@ using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using System.Net;
 
 #if NETSTANDARD1_3
 using System.Collections.Specialized;
-using System.Net;
 using System.Linq.Expressions;
 #endif
 
@@ -53,6 +53,27 @@ namespace ServiceStack
             "--MM--Z",
             "--MM--zzzzzz",
         };
+
+        static readonly Action<HttpWebRequest, string> SetUserAgentDelegate =
+            (Action<HttpWebRequest, string>)typeof(HttpWebRequest)
+                .GetProperty("UserAgent")
+                ?.SetMethod()?.CreateDelegate(typeof(Action<HttpWebRequest, string>));
+
+        static readonly Action<HttpWebRequest, bool> SetAllowAutoRedirectDelegate =
+            (Action<HttpWebRequest, bool>)typeof(HttpWebRequest)
+                .GetProperty("AllowAutoRedirect")
+                ?.SetMethod()?.CreateDelegate(typeof(Action<HttpWebRequest, bool>));
+
+        static readonly Action<HttpWebRequest, bool> SetKeepAliveDelegate =
+            (Action<HttpWebRequest, bool>)typeof(HttpWebRequest)
+                .GetProperty("KeepAlive")
+                ?.SetMethod()?.CreateDelegate(typeof(Action<HttpWebRequest, bool>));
+
+        static readonly Action<HttpWebRequest, long> SetContentLengthDelegate =
+            (Action<HttpWebRequest, long>)typeof(HttpWebRequest)
+                .GetProperty("ContentLength")
+                ?.SetMethod()?.CreateDelegate(typeof(Action<HttpWebRequest, long>));
+
 
         public NetStandardPclExport()
         {
@@ -470,17 +491,48 @@ namespace ServiceStack
             return null;
         }
 
-#if NETSTANDARD1_3
+        public override void SetUserAgent(HttpWebRequest httpReq, string value)
+        {
+            if (SetUserAgentDelegate != null)
+            {
+                SetUserAgentDelegate(httpReq, value);
+            } else 
+            {
+                httpReq.Headers[HttpRequestHeader.UserAgent] = value;
+            }
+        }
+
+        public override void SetContentLength(HttpWebRequest httpReq, long value)
+        {
+            if (SetContentLengthDelegate != null)
+            {
+                SetContentLengthDelegate(httpReq, value);
+            } else 
+            {
+                httpReq.Headers[HttpRequestHeader.ContentLength] = value.ToString();
+            }
+        }
+
+        public override void SetAllowAutoRedirect(HttpWebRequest httpReq, bool value)
+        {
+            SetAllowAutoRedirectDelegate?.Invoke(httpReq, value);
+        }
+
+        public override void SetKeepAlive(HttpWebRequest httpReq, bool value)
+        {
+            SetKeepAliveDelegate?.Invoke(httpReq, value);
+        }
+
         public override void InitHttpWebRequest(HttpWebRequest httpReq,
             long? contentLength = null, bool allowAutoRedirect = true, bool keepAlive = true)
         {
-            httpReq.Headers[HttpRequestHeader.UserAgent] = Env.ServerUserAgent;
-            //httpReq.AllowAutoRedirect = allowAutoRedirect;
-            //httpReq.KeepAlive = keepAlive;
+            SetUserAgent(httpReq, Env.ServerUserAgent);
+            SetAllowAutoRedirect(httpReq, allowAutoRedirect);
+            SetKeepAlive(httpReq, keepAlive);
 
             if (contentLength != null)
             {
-                httpReq.Headers[HttpRequestHeader.ContentLength] = contentLength.Value.ToString();
+                SetContentLength(httpReq, contentLength.Value);
             }
         }
 
@@ -492,13 +544,14 @@ namespace ServiceStack
             bool? preAuthenticate = null)
         {
             //req.MaximumResponseHeadersLength = int.MaxValue; //throws "The message length limit was exceeded" exception
-            //if (allowAutoRedirect.HasValue) req.AllowAutoRedirect = allowAutoRedirect.Value;
+            if (allowAutoRedirect.HasValue) SetAllowAutoRedirect(req, allowAutoRedirect.Value);
             //if (readWriteTimeout.HasValue) req.ReadWriteTimeout = (int)readWriteTimeout.Value.TotalMilliseconds;
             //if (timeout.HasValue) req.Timeout = (int)timeout.Value.TotalMilliseconds;
             if (userAgent != null) req.Headers[HttpRequestHeader.UserAgent] = userAgent;
             //if (preAuthenticate.HasValue) req.PreAuthenticate = preAuthenticate.Value;
         }
         
+#if NETSTANDARD1_3
         public override string GetStackTrace()
         {
             return Environment.StackTrace;

--- a/src/ServiceStack.Text/PclExport.cs
+++ b/src/ServiceStack.Text/PclExport.cs
@@ -264,6 +264,24 @@ namespace ServiceStack
             webReq.Headers[name] = value;
         }
 
+        public virtual void SetUserAgent(HttpWebRequest httpReq, string value)
+        {
+            httpReq.Headers[HttpRequestHeader.UserAgent] = value;
+        }
+
+        public virtual void SetContentLength(HttpWebRequest httpReq, long value)
+        {
+            httpReq.Headers[HttpRequestHeader.ContentLength] = value.ToString();
+        }
+
+        public virtual void SetAllowAutoRedirect(HttpWebRequest httpReq, bool value)
+        {
+        }
+
+        public virtual void SetKeepAlive(HttpWebRequest httpReq, bool value)
+        {
+        }
+
         public virtual Assembly[] GetAllAssemblies()
         {
             return new Assembly[0];

--- a/src/ServiceStack.Text/ReflectionExtensions.cs
+++ b/src/ServiceStack.Text/ReflectionExtensions.cs
@@ -88,19 +88,11 @@ namespace ServiceStack
 #endif
 
 #if NETSTANDARD1_1
-        private static readonly Func<Type, object> GetUninitializedObjectDelegate;
-
-        static ReflectionExtensions()
-        {
-            var formatterServices = typeof(string).GetTypeInfo().Assembly
-               .GetType("System.Runtime.Serialization.FormatterServices");
-            if (formatterServices != null)
-            {
-                var method = formatterServices.GetMethod("GetUninitializedObject");
-                if (method != null)
-                    GetUninitializedObjectDelegate = (Func<Type, object>)method.CreateDelegate(typeof(Func<Type, object>));
-            }
-        }
+        private static readonly Func<Type, object> GetUninitializedObjectDelegate = 
+            (Func<Type, object>) typeof(string).GetTypeInfo().Assembly
+               .GetType("System.Runtime.Serialization.FormatterServices")
+               ?.GetMethod("GetUninitializedObject")
+               ?.CreateDelegate(typeof(Func<Type, object>));
 #endif
 
         public static TypeCode GetTypeCode(this Type type)


### PR DESCRIPTION
Most of HttpWebRequest properties are not implemented on .NET Core,
but they are exist on other platforms such as Xamarin and .NET, so we can try to find the properties by Reflection and call setter on them, if property does not exists just do usual way