### PR TITLE
JsonObject helper class missing non-generic ConvertTo function overload

### DIFF
--- a/src/ServiceStack.Text/JsonObject.cs
+++ b/src/ServiceStack.Text/JsonObject.cs
@@ -179,6 +179,11 @@ namespace ServiceStack.Text
 
         public T ConvertTo<T>()
         {
+            return (T)this.ConvertTo(typeof(T));
+        }
+
+        public object ConvertTo(Type type)
+        {
             var map = new Dictionary<string, object>();
 
             foreach (var entry in this)
@@ -186,7 +191,7 @@ namespace ServiceStack.Text
                 map[entry.Key] = entry.Value;
             }
 
-            return (T)map.FromObjectDictionary(typeof(T));
+            return map.FromObjectDictionary(type);
         }
     }
 


### PR DESCRIPTION
I added an overloaded non-generic ConvertTo function to the JsonObject class which takes in a Type object and made the generic function use this new function to keep the code in one place. 

I need to use this class without knowing the type during the first deserialization forcing the use of reflection to call this function with the type object. Currently I am creating an object which inherits your JsonObject and putting the function there which is adequate, but wanted to see if you thought this was worth putting in your object as well for others.