### PR TITLE
Custom serialization support for CsvSerializer

### DIFF
--- a/src/ServiceStack.Text/TextExtensions.cs
+++ b/src/ServiceStack.Text/TextExtensions.cs
@@ -32,7 +32,16 @@ namespace ServiceStack
 
         public static object ToCsvField(this object text)
         {
-            var textSerialized = TypeSerializer.SerializeToString(text).StripQuotes();
+            var textSerialized = string.Empty;
+            if (text is string)
+            {
+                textSerialized = text.ToString();
+            }
+            else
+            {
+                textSerialized = TypeSerializer.SerializeToString(text).StripQuotes();
+            }
+
             return textSerialized == null || !CsvWriter.HasAnyEscapeChars(textSerialized)
                 ? textSerialized
                 : string.Concat

--- a/src/ServiceStack.Text/TextExtensions.cs
+++ b/src/ServiceStack.Text/TextExtensions.cs
@@ -32,12 +32,13 @@ namespace ServiceStack
 
         public static object ToCsvField(this object text)
         {
-            return text == null || !CsvWriter.HasAnyEscapeChars(text.ToString())
-                ? text
+            var textSerialized = TypeSerializer.SerializeToString(text).StripQuotes();
+            return textSerialized == null || !CsvWriter.HasAnyEscapeChars(textSerialized)
+                ? textSerialized
                 : string.Concat
                   (
                       CsvConfig.ItemDelimiterString,
-                      text.ToString().Replace(CsvConfig.ItemDelimiterString, CsvConfig.EscapedItemDelimiterString),
+                      textSerialized.Replace(CsvConfig.ItemDelimiterString, CsvConfig.EscapedItemDelimiterString),
                       CsvConfig.ItemDelimiterString
                   );
         }

--- a/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
@@ -1,0 +1,116 @@
+using NUnit.Framework;
+using System;
+
+namespace ServiceStack.Text.Tests.CsvTests
+{
+    [TestFixture]
+    public class ObjectSerializerTests
+    {
+        [Test]
+        public void IEnumerableObjectSerialization()
+        {
+            var data = GenerateSampleData();
+
+            JsConfig<DateTime>.SerializeFn =
+                time => new DateTime(time.Ticks, DateTimeKind.Utc).ToString("yyyy-MM-dd HH:mm:ss");
+
+            var csv = CsvSerializer.SerializeToCsv(data);
+            Console.WriteLine(csv);
+
+            Assert.AreEqual("DateTime\r\n"
+                + "2017-06-14 00:00:00\r\n"
+                + "2017-01-31 01:23:45\r\n",
+                csv);
+        }
+
+        [Test]
+        public void IEnumerableObjectSerializationBaseline()
+        {
+            var data = new object[]
+            {
+                new { Value = true },
+                new { Value = false },
+                new { Value = new bool?() }
+            };
+
+            var csv = CsvSerializer.SerializeToCsv(data);
+            Console.WriteLine(csv);
+
+            Assert.AreEqual("Value\r\n"
+                + "True\r\n"
+                + "False\r\n"
+                + "\r\n",
+                csv);
+        }
+
+        [Test]
+        public void IEnumerableObjectSerializationCustomSerializer()
+        {
+            var data = new object[]
+            {
+                new { Value = true },
+                new { Value = false }
+            };
+
+            JsConfig<bool>.SerializeFn =
+                value => value == true ? "Yes" : "No";
+
+            var csv = CsvSerializer.SerializeToCsv(data);
+            Console.WriteLine(csv);
+
+            Assert.AreEqual("Value\r\n"
+                + "Yes\r\n"
+                + "No\r\n",
+                csv);
+        }
+
+        [Test]
+        public void IEnumerableObjectSerializationCustomSerializerOfNullableType()
+        {
+            var data = new object[]
+            {
+                new { Value = new bool?(true) },
+                new { Value = new bool?(false) },
+                new { Value = new bool?() }
+            };
+
+            JsConfig<bool?>.SerializeFn =
+                value => value.HasValue ? (value == true ? "Yes" : "No") : "Maybe";
+
+            var csv = CsvSerializer.SerializeToCsv(data);
+            Console.WriteLine(csv);
+
+            Assert.AreEqual("Value\r\n"
+                + "Yes\r\n"
+                + "No\r\n"
+                + "\r\n",
+                csv);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            CsvConfig.Reset();
+        }
+
+        object[] GenerateSampleData()
+        {
+            return new object[] {
+            new POCO
+            {
+                DateTime = new DateTime(2017,6,14)
+            },
+            new POCO
+            {
+                DateTime = new DateTime(2017,1,31, 01, 23, 45)
+            }
+         };
+        }
+
+    }
+
+    public class POCO
+    {
+        public DateTime DateTime { get; set; }
+    }
+}

--- a/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
@@ -87,10 +87,18 @@ namespace ServiceStack.Text.Tests.CsvTests
                 csv);
         }
 
-        [TearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
+            JsConfig<bool>.SerializeFn = null;
+            JsConfig<bool>.Reset();
+            JsConfig<bool?>.SerializeFn = null;
+            JsConfig<bool?>.Reset();
+            JsConfig<DateTime>.SerializeFn = null;
+            JsConfig<DateTime>.Reset();
+
             CsvConfig.Reset();
+            JsConfig.Reset();
         }
 
         object[] GenerateSampleData()


### PR DESCRIPTION
Unlike JsonSerializer, CsvSerializer does not utilise TypeSerializer and therefore does not support custom serialization.

This PR implements this support with a relatively simple change to the ToCsvField extension method.