### PR TITLE
Fix deserialization error when CSV values contains unmatched { or [ symbol

### DIFF
--- a/src/ServiceStack.Text/CsvConfig.cs
+++ b/src/ServiceStack.Text/CsvConfig.cs
@@ -19,6 +19,8 @@ namespace ServiceStack.Text
             set { sRealNumberCultureInfo = value; }
         }
 
+        public static bool RecognizeJsonInValue { get; set; } = true;
+
         [ThreadStatic]
         private static string tsItemSeperatorString;
         private static string sItemSeperatorString;
@@ -124,6 +126,7 @@ namespace ServiceStack.Text
             tsEscapedItemDelimiterString = sEscapedItemDelimiterString = null;
             tsRowSeparatorString = sRowSeparatorString = null;
             tsEscapeStrings = sEscapeStrings = null;
+            RecognizeJsonInValue = true;
         }
 
     }

--- a/src/ServiceStack.Text/CsvReader.cs
+++ b/src/ServiceStack.Text/CsvReader.cs
@@ -90,7 +90,7 @@ namespace ServiceStack.Text
                 ? CsvConfig.ItemSeperatorString[0]
                 : JsWriter.ItemSeperator;
 
-            if (valueChar == itemSeperator || valueChar == JsWriter.MapEndChar)
+            if (valueChar == itemSeperator || (CsvConfig.RecognizeJsonInValue && valueChar == JsWriter.MapEndChar))
                 return null;
 
             if (valueChar == JsWriter.QuoteChar) //Is Within Quotes, i.e. "..."
@@ -109,7 +109,7 @@ namespace ServiceStack.Text
                 }
                 return value.Substring(tokenStartPos, i - tokenStartPos);
             }
-            if (valueChar == JsWriter.MapStartChar) //Is Type/Map, i.e. {...}
+            if (CsvConfig.RecognizeJsonInValue && valueChar == JsWriter.MapStartChar) //Is Type/Map, i.e. {...}
             {
                 while (++i < valueLength && endsToEat > 0)
                 {
@@ -129,7 +129,7 @@ namespace ServiceStack.Text
                 }
                 return value.Substring(tokenStartPos, i - tokenStartPos);
             }
-            if (valueChar == JsWriter.ListStartChar) //Is List, i.e. [...]
+            if (CsvConfig.RecognizeJsonInValue && valueChar == JsWriter.ListStartChar) //Is List, i.e. [...]
             {
                 while (++i < valueLength && endsToEat > 0)
                 {
@@ -154,7 +154,7 @@ namespace ServiceStack.Text
             {
                 valueChar = value[i];
 
-                if (valueChar == itemSeperator || valueChar == JsWriter.MapEndChar)
+                if (valueChar == itemSeperator || (CsvConfig.RecognizeJsonInValue && valueChar == JsWriter.MapEndChar))
                 {
                     break;
                 }

--- a/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
@@ -1,5 +1,7 @@
 using NUnit.Framework;
+using ServiceStack.Text.Common;
 using System;
+using System.Collections.Generic;
 
 namespace ServiceStack.Text.Tests.CsvTests
 {
@@ -115,10 +117,42 @@ namespace ServiceStack.Text.Tests.CsvTests
          };
         }
 
+
+        [Test]
+        public void UnmatchJsonCharDeserialization()
+        {
+            var src = new List<POCO2>() {
+                new POCO2()
+                {
+                    Prop1 = "1",
+                    Prop2 = JsWriter.ListStartChar + "2",
+                    Prop3 = JsWriter.MapStartChar + "3",
+                    Prop4 = "4",
+                    Prop5 = "5"
+                }
+            };
+            var csv = CsvSerializer.SerializeToCsv<POCO2>(src);
+            var des = csv.FromCsv<List<POCO2>>();
+            Assert.AreNotEqual(src[0].Prop5, des[0].Prop5);
+
+            CsvConfig.RecognizeJsonInValue = false;
+            des = csv.FromCsv<List<POCO2>>();
+            Assert.AreEqual(src[0].Prop5, des[0].Prop5);
+        }
     }
 
     public class POCO
     {
         public DateTime DateTime { get; set; }
     }
+
+    public class POCO2
+    {
+        public string Prop1 { get; set; }
+        public string Prop2 { get; set; }
+        public string Prop3 { get; set; }
+        public string Prop4 { get; set; }
+        public string Prop5 { get; set; }
+    }
+
 }

--- a/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
+++ b/tests/ServiceStack.Text.Tests/ServiceStack.Text.Tests.csproj
@@ -20,6 +20,10 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
 
+  <PropertyGroup> 
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType> 
+  </PropertyGroup>  
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\ServiceStack.Text\ServiceStack.Text.csproj" />
   </ItemGroup>
@@ -83,6 +87,10 @@
     <Reference Include="..\..\lib\netstandard1.3\ServiceStack.Common.dll" />
     <Reference Include="..\..\lib\netstandard1.6\ServiceStack.dll" />
     <Reference Include="..\..\lib\netstandard1.3\Northwind.Common.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Here's the [Gist](http://gistlyn.com/?gist=d0422d17efde5d3e95c4ce4173c70e69) to reproduce problem.

When property value or CSV row string contains unmatched { or [ symbol, CsvFrom or CsvReader can't split the values correctly, although they are valid in CSV format.

I added CsvConfig.RecognizeJsonInValue flag to allow EatValue to ignore JsWriter.MapStartChar and JsWtier.ListStartChar character.  RecognizeJsonInValue  is true by default now to avoid changing the behavior, or we should set it to false by default to meet general scenarios?