### PR TITLE
Fix for dictionary object with empty string

### DIFF
--- a/src/ServiceStack.Text/TextExtensions.cs
+++ b/src/ServiceStack.Text/TextExtensions.cs
@@ -42,7 +42,7 @@ namespace ServiceStack
                 textSerialized = TypeSerializer.SerializeToString(text).StripQuotes();
             }
 
-            return textSerialized == null || !CsvWriter.HasAnyEscapeChars(textSerialized)
+            return textSerialized.IsNullOrEmpty() || !CsvWriter.HasAnyEscapeChars(textSerialized)
                 ? textSerialized
                 : string.Concat
                   (

--- a/tests/ServiceStack.Text.Tests/CsvSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvSerializerTests.cs
@@ -336,6 +336,26 @@ namespace ServiceStack.Text.Tests
         }
 
         [Test]
+        public void Can_serialize_single_ObjectDictionary_or_ObjectKvps_WithEmptyString()
+        {
+            var row = new Dictionary<string, object>
+            {
+                { "Id", 1 },
+                { "CustomerId", "" },
+            };
+
+            Assert.That(row.ToCsv().NormalizeNewLines(), Is.EqualTo("Id,CustomerId\n1,").Or.EqualTo("CustomerId,Id\n,1"));
+
+            var kvps = new[]
+            {
+                new KeyValuePair<string, object>("Id", 1),
+                new KeyValuePair<string, object>("CustomerId", ""),
+            };
+
+            Assert.That(kvps.ToCsv().NormalizeNewLines(), Is.EqualTo("Id,CustomerId\n1,").Or.EqualTo("CustomerId,Id\n,1"));
+        }
+        
+        [Test]
         public void Can_serialize_single_StringDictionary_or_StringKvps()
         {
             var row = new Dictionary<string, string>

--- a/tests/ServiceStack.Text.Tests/JsonTests/RouteValueDictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/RouteValueDictionaryTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 using System.Web.Routing;
 using NUnit.Framework;
 using ServiceStack.Html;
+using RouteValueDictionary = ServiceStack.Html.RouteValueDictionary;
 
 namespace ServiceStack.Text.Tests.JsonTests
 {

--- a/tests/ServiceStack.Text.Tests/JsonTests/RouteValueDictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/RouteValueDictionaryTests.cs
@@ -4,7 +4,6 @@ using System.Runtime.Serialization;
 using System.Web.Routing;
 using NUnit.Framework;
 using ServiceStack.Html;
-using RouteValueDictionary = ServiceStack.Html.RouteValueDictionary;
 
 namespace ServiceStack.Text.Tests.JsonTests
 {


### PR DESCRIPTION
Csv serialisation of collection of Dictionary or Dynamic types with empty string generates index out of range exception. 