### PR TITLE
JsonSerializer/JsvTypeSerializer inconsistently uses the AssumeUtc config setting

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -442,6 +442,7 @@ namespace ServiceStack.Text.Common
 
         public static string ToShortestXsdDateTimeString(DateTime dateTime)
         {
+            dateTime = dateTime.UseConfigSpecifiedSetting();
             var timeOfDay = dateTime.TimeOfDay;
 
             var isStartOfDay = timeOfDay.Ticks == 0;
@@ -582,13 +583,18 @@ namespace ServiceStack.Text.Common
 
         internal static TimeZoneInfo LocalTimeZone = GetLocalTimeZoneInfo();
 
-        public static void WriteWcfJsonDate(TextWriter writer, DateTime dateTime)
+        private static DateTime UseConfigSpecifiedSetting(this DateTime dateTime)
         {
             if (JsConfig.AssumeUtc && dateTime.Kind == DateTimeKind.Unspecified)
             {
-                dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+                return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
             }
+            return dateTime;
+        }
 
+        public static void WriteWcfJsonDate(TextWriter writer, DateTime dateTime)
+        {
+            dateTime = dateTime.UseConfigSpecifiedSetting();
             switch (JsConfig.DateHandler)
             {
                 case DateHandler.ISO8601:

--- a/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NUnit.Framework;
 using ServiceStack.Text.Common;
+using ServiceStack.Text.Jsv;
 
 namespace ServiceStack.Text.Tests.JsonTests
 {
@@ -307,6 +308,27 @@ namespace ServiceStack.Text.Tests.JsonTests
 
             Assert.AreEqual(DateTimeKind.Utc, deserializedDate.Kind);
             Assert.AreEqual(initialDate, deserializedDate);
+        }
+
+        [Test]
+        public void ISO8601_assumeUtc_serialize_datetime_is_the_same()
+        {
+            JsConfig.AssumeUtc = true;
+            JsConfig.DateHandler = DateHandler.ISO8601;
+            var initialDate = new DateTime(2012, 7, 25, 16, 17, 00, DateTimeKind.Unspecified);
+            var writers = new
+            {
+                jsv = new System.IO.StringWriter(new System.Text.StringBuilder()),
+                json = new System.IO.StringWriter(new System.Text.StringBuilder())
+            };
+            new JsvTypeSerializer().WriteDateTime(writers.jsv, initialDate);
+            new Json.JsonTypeSerializer().WriteDateTime(writers.json, initialDate);
+            var results = new
+            {
+                jsv = DateTime.SpecifyKind(DateTime.Parse(writers.jsv.ToString()), DateTimeKind.Utc),
+                json = DateTime.SpecifyKind(DateTime.Parse(writers.json.ToString().Replace("\"", "")), DateTimeKind.Utc)
+            };
+            Assert.AreEqual(results.jsv, results.json);
         }
 
         [Test]


### PR DESCRIPTION
**DateTime** handling is inconsistent with respect to the `AssumcUtc` when using the `JSConfig` setting.

If serializing to **JSON** - The `JsonTypeSerializer` will use the **UTC** specification type and convert `Unspecified` **DateTime** values to **UTC** in method `WriteWcfJsonDate`

If serializing to **CSV**- The `JsvTypeSerializer` will not use the **UTC** specification type and does not convert `Unspecified` **DateTime** values to **UTC** in method `ToShortestXsdDateTimeString`

Adding an internal extension method `UseConfigSpecifiedSetting` to match **DateTime** conversion between the two different serializers.