### PR TITLE
A data contract class with inherited non-public data members causes an NRE on deserialization

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeType.cs
+++ b/src/ServiceStack.Text/Common/DeserializeType.cs
@@ -285,7 +285,7 @@ namespace ServiceStack.Text.Common
         private static SetMemberDelegate GetSetPropertyMethod(TypeConfig typeConfig, PropertyInfo propertyInfo)
         {
             if (typeConfig.Type != propertyInfo.DeclaringType)
-                propertyInfo = propertyInfo.DeclaringType.GetProperty(propertyInfo.Name);
+                propertyInfo = propertyInfo.DeclaringType.GetProperty(propertyInfo.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             if (!propertyInfo.CanWrite && !typeConfig.EnableAnonymousFieldSetters) return null;
 
@@ -326,7 +326,7 @@ namespace ServiceStack.Text.Common
         private static SetMemberDelegate GetSetFieldMethod(TypeConfig typeConfig, FieldInfo fieldInfo)
         {
             if (typeConfig.Type != fieldInfo.DeclaringType)
-                fieldInfo = fieldInfo.DeclaringType.GetField(fieldInfo.Name);
+                fieldInfo = fieldInfo.DeclaringType.GetField(fieldInfo.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             return PclExport.Instance.CreateSetter(fieldInfo);
         }

--- a/tests/ServiceStack.Text.Tests/ReportedIssues.cs
+++ b/tests/ServiceStack.Text.Tests/ReportedIssues.cs
@@ -330,6 +330,68 @@ namespace ServiceStack.Text.Tests
             var deserialized = TypeSerializer.DeserializeFromString<TestMappedList>(serialized);
             Assert.That(deserialized.IntArrayProp, Is.EqualTo(type.IntArrayProp));
         }
+
+
+        [Test]
+        public void Null_Reference_Exception_On_Inherited_Field_With_No_Setter()
+        {
+            string testString = null;
+            InheritedFieldErrorTest parentClass = new InheritedFieldErrorTest(), parentClassResult = null;
+            InheritedFieldErrorTestChild childClass = new InheritedFieldErrorTestChild(), childClassResult = null;
+            Assert.DoesNotThrow(() => { testString = JsonSerializer.SerializeToString(parentClass); });
+            Assert.IsNotNull(testString);
+            Assert.IsNotEmpty(testString);
+            Assert.DoesNotThrow(() => { parentClassResult = JsonSerializer.DeserializeFromString<InheritedFieldErrorTest>(testString); });
+            Assert.IsNotNull(parentClassResult);
+            Assert.DoesNotThrow(() => { testString = JsonSerializer.SerializeToString(childClass); });
+            Assert.IsNotNull(testString);
+            Assert.IsNotEmpty(testString);
+            Assert.DoesNotThrow(() => { childClassResult = JsonSerializer.DeserializeFromString<InheritedFieldErrorTestChild>(testString); });
+            Assert.IsNotNull(childClassResult);
+        }
+
+        [System.Runtime.Serialization.DataContract]
+        public class InheritedFieldErrorTest
+        {
+            [System.Runtime.Serialization.DataMember]
+            protected bool test = false;
+        }
+
+        [System.Runtime.Serialization.DataContract]
+        public class InheritedFieldErrorTestChild : InheritedFieldErrorTest
+        {
+        }
+
+        [Test]
+        public void Null_Reference_Exception_On_Inherited_Property_With_No_Setter()
+        {
+            string testString = null;
+            InheritedPropertyErrorTest parentClass = new InheritedPropertyErrorTest(), parentClassResult = null;
+            InheritedPropertyErrorTestChild childClass = new InheritedPropertyErrorTestChild(), childClassResult = null;
+            Assert.DoesNotThrow(() => { testString = JsonSerializer.SerializeToString(parentClass); });
+            Assert.IsNotNull(testString);
+            Assert.IsNotEmpty(testString);
+            Assert.DoesNotThrow(() => { parentClassResult = JsonSerializer.DeserializeFromString<InheritedPropertyErrorTest>(testString); });
+            Assert.IsNotNull(parentClassResult);
+            Assert.DoesNotThrow(() => { testString = JsonSerializer.SerializeToString(childClass); });
+            Assert.IsNotNull(testString);
+            Assert.IsNotEmpty(testString);
+            Assert.DoesNotThrow(() => { childClassResult = JsonSerializer.DeserializeFromString<InheritedPropertyErrorTestChild>(testString); });
+            Assert.IsNotNull(childClassResult);
+        }
+
+
+        [System.Runtime.Serialization.DataContract]
+        public class InheritedPropertyErrorTest
+        {
+            [System.Runtime.Serialization.DataMember]
+            protected bool Test { get; }
+        }
+
+        [System.Runtime.Serialization.DataContract]
+        public class InheritedPropertyErrorTestChild : InheritedPropertyErrorTest
+        {
+        }
     }
 
     public class TestMappedList


### PR DESCRIPTION
Child classes marked as DataContract inheriting protected DataMember fields and properties causes a NullReferenceException to be thrown on deserialization.

I stumbled upon this issue on accident when I mistakenly applied the DataMember property to a protected property of a parent class. This mistake unfortunately caused a NullReferenceException which was not easy to diagnose since I assumed the problem must have been in some other logic since I never intended to serialize the property the first place.

The change of the binding flags is just one possible way to alleviate the problem. Looks to be possible to return null from GetSetPropertyMethod, but I did not look further into GetSetFieldMethod to see if returning null was possible there. There are probably other ways to solve the problem, but probably not intended to throw an especially hard to trace NRE. 

Unit tests added to show the problem. Made sure they failed before adding my change. I believe they also have the side effect of making JsConfig.Reset() fail as well which causes problems in a lot of tests, so FYI. Best to run these tests separately if they are expected to fail otherwise there are a lot of false positives. 

Let me know if there's anything else I need to do.

Thanks,
Chris