### PR TITLE
DateTimes that are exported in ISO8601 are not consistent across serialization formats JSON/XML/CSV

### DIFF
--- a/src/ServiceStack.Text/Common/DateTimeSerializer.cs
+++ b/src/ServiceStack.Text/Common/DateTimeSerializer.cs
@@ -443,8 +443,12 @@ namespace ServiceStack.Text.Common
         public static string ToShortestXsdDateTimeString(DateTime dateTime)
         {
             dateTime = dateTime.UseConfigSpecifiedSetting();
-            var timeOfDay = dateTime.TimeOfDay;
+            if (!string.IsNullOrEmpty(JsConfig.DateTimeFormat))
+            {
+                return dateTime.ToString(JsConfig.DateTimeFormat, CultureInfo.InvariantCulture);
+            }
 
+            var timeOfDay = dateTime.TimeOfDay;
             var isStartOfDay = timeOfDay.Ticks == 0;
             if (isStartOfDay && !JsConfig.SkipDateTimeConversion)
                 return dateTime.ToString(ShortDateTimeFormat, CultureInfo.InvariantCulture);

--- a/src/ServiceStack.Text/JsConfig.cs
+++ b/src/ServiceStack.Text/JsConfig.cs
@@ -222,6 +222,7 @@ namespace ServiceStack.Text
             bool? preferInterfaces = null,
             bool? throwOnDeserializationError = null,
             string typeAttr = null,
+            string dateTimeFormat = null,
             Func<Type, string> typeWriter = null,
             Func<string, Type> typeFinder = null,
             bool? treatEnumAsInteger = null,
@@ -258,6 +259,7 @@ namespace ServiceStack.Text
                 PropertyConvention = propertyConvention ?? sPropertyConvention,
                 PreferInterfaces = preferInterfaces ?? sPreferInterfaces,
                 ThrowOnDeserializationError = throwOnDeserializationError ?? sThrowOnDeserializationError,
+                DateTimeFormat = dateTimeFormat ?? sDateTimeFormat,
                 TypeAttr = typeAttr ?? sTypeAttr,
                 TypeWriter = typeWriter ?? sTypeWriter,
                 TypeFinder = typeFinder ?? sTypeFinder,
@@ -272,6 +274,21 @@ namespace ServiceStack.Text
                 ModelFactory = modelFactory ?? ModelFactory,
                 ExcludePropertyReferences = excludePropertyReferences ?? sExcludePropertyReferences,
             };
+        }
+
+        private static string sDateTimeFormat;
+        public static string DateTimeFormat
+        {
+            get
+            {
+                return (JsConfigScope.Current != null ? JsConfigScope.Current.DateTimeFormat : null)
+                       ?? sDateTimeFormat;
+                       //?? DateTimeSerializer.XsdDateTimeFormatSeconds;
+            }
+            set
+            {
+                if (sDateTimeFormat == null) sDateTimeFormat = value;
+            }
         }
 
         private static bool? sConvertObjectTypesIntoStringDictionary;
@@ -974,6 +991,7 @@ namespace ServiceStack.Text
             sPreferInterfaces = null;
             sThrowOnDeserializationError = null;
             sTypeAttr = null;
+            sDateTimeFormat = null;
             sJsonTypeAttrInObject = null;
             sJsvTypeAttrInObject = null;
             sTypeWriter = null;

--- a/src/ServiceStack.Text/JsConfigScope.cs
+++ b/src/ServiceStack.Text/JsConfigScope.cs
@@ -61,6 +61,7 @@ namespace ServiceStack.Text
         public bool? ExcludeTypeInfo { get; set; }
         public bool? IncludeTypeInfo { get; set; }
         public string TypeAttr { get; set; }
+        public string DateTimeFormat { get; set; }
         internal string JsonTypeAttrInObject { get; set; }
         internal string JsvTypeAttrInObject { get; set; }
         public Func<Type, string> TypeWriter { get; set; }

--- a/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using ServiceStack.Text.Common;
 
 namespace ServiceStack.Text.Tests.CsvTests
@@ -8,6 +9,56 @@ namespace ServiceStack.Text.Tests.CsvTests
     [TestFixture]
     public class ObjectSerializerTests
     {
+        [Test]
+        public void MidnightAndNoonTestSerialization()
+        {
+            JsConfig.Reset();
+            JsConfig<DateTime>.SerializeFn = null;
+            JsConfig<DateTime>.Reset();
+
+            JsConfig.AlwaysUseUtc = true;
+            JsConfig.AssumeUtc = true;
+            // Set the format for DatTimeFormatting explicitly using DateTimeSerializer.XsdDateTimeFormat because it is ISO8601 fractional seconds
+            JsConfig.DateTimeFormat = DateTimeSerializer.XsdDateTimeFormat;
+
+            var midnight = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var noon = midnight.AddHours(12);
+            var dotnetValues = new
+            {
+                Midnight = midnight.ToString("o"),
+                Noon = noon.ToString("o")
+            };
+            var data = new object[] {
+                    new POCO { DateTime = midnight },
+                    new POCO { DateTime = noon }
+                    };
+            var csv = CsvSerializer.SerializeToCsv(data);
+            // Reset back to defaults
+            JsConfig.Reset();
+            JsConfig<DateTime>.SerializeFn = null;
+            JsConfig<DateTime>.Reset();
+
+            Console.WriteLine(csv);
+
+            const string endLineChars = "\r\n";
+            Assert.AreEqual($"DateTime{endLineChars}" +
+                            $"{dotnetValues.Midnight}{endLineChars}" +
+                            $"{dotnetValues.Noon}{endLineChars}", csv);
+
+            // Now don't use custom DateTimeFormat
+            JsConfig.AlwaysUseUtc = true;
+            JsConfig.AssumeUtc = true;            
+            csv = CsvSerializer.SerializeToCsv(data);
+            Console.WriteLine(csv);
+            Assert.AreEqual($"DateTime{endLineChars}" +
+                            $"2018-01-01{endLineChars}" +
+                            $"2018-01-01T12:00:00Z{endLineChars}", csv);
+
+            JsConfig.Reset();
+            JsConfig<DateTime>.SerializeFn = null;
+            JsConfig<DateTime>.Reset();
+        }
+
         [Test]
         public void IEnumerableObjectSerialization()
         {

--- a/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using ServiceStack.Text.Common;
 
 namespace ServiceStack.Text.Tests.CsvTests


### PR DESCRIPTION
JSON and XML both show a datetime with the fractional seconds like so

`2018-02-10T00:00:00.0000000Z`

but CSV will produce a DateTime with out the any of the timespan portion of timezone indicator i.e.

`2018-01-01`

this is also not consistent with the default ISO8601 parser in .NET for DateTime called as so `.ToString("o")` will produce the ISO8601 serialized times as for JSON and XML, but not CSV.

Adding the ability to specify a DateTimeFormat that will allow a user to override the DateTimeFormat defaults so serialized value is consistent.

Using the `JsConfig<DateTime>.SerializeFn` is a way for me to personally fix this, but point 1 I would then be overriding default behavior for all serialization types because I want them to be consistent in how they write serialized values which I think by default they should all match and then I can use that function for personal modification of this format and point 2 this is just another thing I need to remind myself over on serialization versus simply specifying the DateTime target format.

However the core problem of inconsistent serialization for these edge cases of midnight CSV versus midnight JSON are what I would like to get sorted out in this PR.  