### PR TITLE
Support IReadOnlyDictionary in FromObjectDictionary

### DIFF
--- a/src/ServiceStack.Text/PlatformExtensions.cs
+++ b/src/ServiceStack.Text/PlatformExtensions.cs
@@ -674,9 +674,9 @@ namespace ServiceStack
             return dict;
         }
 
-        public static object FromObjectDictionary(this Dictionary<string, object> values, Type type)
+        public static object FromObjectDictionary(this IReadOnlyDictionary<string, object> values, Type type)
         {
-            var alreadyDict = type == typeof(Dictionary<string, object>);
+            var alreadyDict = type == typeof(IReadOnlyDictionary<string, object>);
             if (alreadyDict)
                 return true;
 
@@ -696,7 +696,7 @@ namespace ServiceStack
             return to;
         }
 
-        public static T FromObjectDictionary<T>(this Dictionary<string, object> values)
+        public static T FromObjectDictionary<T>(this IReadOnlyDictionary<string, object> values)
         {
             return (T)values.FromObjectDictionary(typeof(T));
         }

--- a/tests/ServiceStack.Text.Tests/AutoMappingObjectDictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/AutoMappingObjectDictionaryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Northwind.Common.DataModel;
 using NUnit.Framework;
 
@@ -73,6 +74,25 @@ namespace ServiceStack.Text.Tests
             };
 
             var fromDict = (User)map.FromObjectDictionary(typeof(User));
+            Assert.That(fromDict.FirstName, Is.EqualTo("1"));
+            Assert.That(fromDict.LastName, Is.EqualTo(bool.TrueString));
+            Assert.That(fromDict.Car.Age, Is.EqualTo(10));
+            Assert.That(fromDict.Car.Name, Is.EqualTo("SubCar"));
+        }
+
+        [Test]
+        public void Can_Convert_from_ObjectDictionary_with_Read_Only_Dictionary()
+        {
+            var map = new Dictionary<string, object>
+            {
+                { "FirstName", 1 },
+                { "LastName", true },
+                { "Car",  new SubCar { Age = 10, Name = "SubCar", Custom = "Custom"} },
+            };
+
+            var readOnlyMap = new ReadOnlyDictionary<string, object>(map);
+
+            var fromDict = (User)readOnlyMap.FromObjectDictionary(typeof(User));
             Assert.That(fromDict.FirstName, Is.EqualTo("1"));
             Assert.That(fromDict.LastName, Is.EqualTo(bool.TrueString));
             Assert.That(fromDict.Car.Age, Is.EqualTo(10));


### PR DESCRIPTION
We're working on a Neo4j User Auth Repository but their low-level [driver](https://github.com/neo4j/neo4j-dotnet-driver) is a little tricky to handle deserialization via IRecord. The FromObjectDictionary method (I think) will work nicely if it can support interfaces.