### PR TITLE
Time span converter culture

### DIFF
--- a/src/ServiceStack.Text/Support/TimeSpanConverter.cs
+++ b/src/ServiceStack.Text/Support/TimeSpanConverter.cs
@@ -36,7 +36,7 @@ namespace ServiceStack.Text.Support
 
                 if (remainingSecs > 0)
                 {
-                    var secFmt = string.Format("{0:0.0000000}", remainingSecs);
+                    var secFmt = string.Format(CultureInfo.InvariantCulture, "{0:0.0000000}", remainingSecs);
                     secFmt = secFmt.TrimEnd('0').TrimEnd('.');
                     sb.Append(secFmt + "S");
                 }
@@ -96,7 +96,7 @@ namespace ServiceStack.Text.Support
                 if (s.Length == 2)
                 {
                     decimal millis;
-                    if (decimal.TryParse(s[0], out millis))
+                    if (decimal.TryParse(s[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out millis))
                         seconds = millis;
                 }
             }

--- a/tests/ServiceStack.Text.Tests/TimeSpanConverterTests.cs
+++ b/tests/ServiceStack.Text.Tests/TimeSpanConverterTests.cs
@@ -81,5 +81,68 @@ namespace ServiceStack.Text.Tests
             Assert.That(TimeSpanConverter.FromXsdDuration("P3605D"), Is.EqualTo(threeThousandSixHundredAndFiveDays));
             Assert.That(TimeSpanConverter.FromXsdDuration("-P3605D"), Is.EqualTo(-threeThousandSixHundredAndFiveDays));
         }
+
+        [Test]
+        public void Can_Serialize_TimeSpan_DifferentCulture()
+        {
+            var culture = new CultureInfo("sl-SI");
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneDay), Is.EqualTo("P1D"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneHour), Is.EqualTo("PT1H"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneMinute), Is.EqualTo("PT1M"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneSecond), Is.EqualTo("PT1S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneMilliSecond), Is.EqualTo("PT0.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneDayHourMinuteSecondMilliSecond), Is.EqualTo("P1DT1H1M1.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(arbitraryTimeSpan), Is.EqualTo("P1DT2H3M4.5670001S"));
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneDay), Is.EqualTo("-P1D"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneHour), Is.EqualTo("-PT1H"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneMinute), Is.EqualTo("-PT1M"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneSecond), Is.EqualTo("-PT1S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneMilliSecond), Is.EqualTo("-PT0.001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-arbitraryTimeSpan), Is.EqualTo("-P1DT2H3M4.5670001S"));
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(oneTick), Is.EqualTo("PT0.0000001S"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-oneTick), Is.EqualTo("-PT0.0000001S"));
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(TimeSpan.Zero), Is.EqualTo("PT0S"));
+
+            Assert.That(TimeSpanConverter.ToXsdDuration(threeThousandSixHundredAndFiveDays), Is.EqualTo("P3605D"));
+            Assert.That(TimeSpanConverter.ToXsdDuration(-threeThousandSixHundredAndFiveDays), Is.EqualTo("-P3605D"));
+        }
+
+        [Test]
+        public void Can_deserialize_TimeSpan_DifferentCulture()
+        {
+            var culture = new CultureInfo("sl-SI");
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("P1D"), Is.EqualTo(oneDay));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT1H"), Is.EqualTo(oneHour));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT1M"), Is.EqualTo(oneMinute));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT1S"), Is.EqualTo(oneSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT0.001S"), Is.EqualTo(oneMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("P1DT1H1M1.001S"), Is.EqualTo(oneDayHourMinuteSecondMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("P1DT2H3M4.5670001S"), Is.EqualTo(arbitraryTimeSpan));
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P1D"), Is.EqualTo(-oneDay));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT1H"), Is.EqualTo(-oneHour));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT1M"), Is.EqualTo(-oneMinute));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT1S"), Is.EqualTo(-oneSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT0.001S"), Is.EqualTo(-oneMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P1DT1H1M1.001S"), Is.EqualTo(-oneDayHourMinuteSecondMilliSecond));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P1DT2H3M4.5670001S"), Is.EqualTo(-arbitraryTimeSpan));
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT0.0000001S"), Is.EqualTo(oneTick));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-PT0.0000001S"), Is.EqualTo(-oneTick));
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("PT0S"), Is.EqualTo(TimeSpan.Zero));
+
+            Assert.That(TimeSpanConverter.FromXsdDuration("P3605D"), Is.EqualTo(threeThousandSixHundredAndFiveDays));
+            Assert.That(TimeSpanConverter.FromXsdDuration("-P3605D"), Is.EqualTo(-threeThousandSixHundredAndFiveDays));
+        }
     }
 }

--- a/tests/ServiceStack.Text.Tests/TimeSpanConverterTests.cs
+++ b/tests/ServiceStack.Text.Tests/TimeSpanConverterTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using ServiceStack.Text.Support;
 
@@ -20,6 +22,10 @@ namespace ServiceStack.Text.Tests
         [Test]
         public void Can_Serialize_TimeSpan()
         {
+            var culture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+
             Assert.That(TimeSpanConverter.ToXsdDuration(oneDay), Is.EqualTo("P1D"));
             Assert.That(TimeSpanConverter.ToXsdDuration(oneHour), Is.EqualTo("PT1H"));
             Assert.That(TimeSpanConverter.ToXsdDuration(oneMinute), Is.EqualTo("PT1M"));
@@ -47,6 +53,10 @@ namespace ServiceStack.Text.Tests
         [Test]
         public void Can_deserialize_TimeSpan()
         {
+            var culture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+
             Assert.That(TimeSpanConverter.FromXsdDuration("P1D"), Is.EqualTo(oneDay));
             Assert.That(TimeSpanConverter.FromXsdDuration("PT1H"), Is.EqualTo(oneHour));
             Assert.That(TimeSpanConverter.FromXsdDuration("PT1M"), Is.EqualTo(oneMinute));


### PR DESCRIPTION
Hi

My pull request first show culture depended problem in converting TimeSpan to XsdDuration string and from string. In last commit I'm suggesting the solution.

1. By default tests: **Can_Serialize_TimeSpan** and **Can_deserialize_TimeSpan** failed on my computer because I use different culture so I have corrected this two tests to replicate good result on my computer: 
https://github.com/ServiceStack/ServiceStack.Text/commit/a16175af3ecf85015cf84ebefdd8fede4650284a

2. In https://github.com/ServiceStack/ServiceStack.Text/commit/4d009f82cf487c420a354867d5bc07f8d6480c34 I have add another two tests with using my culture to replicate problem on your computers.

3. In 
https://github.com/ServiceStack/ServiceStack.Text/commit/47a7f57b12af7dc47b807623e8af95d9994cb4cd I'm suggesting the solution to correct culture depend conversions.
