### PR TITLE
Added support for inherited JsonObject types.

### DIFF
--- a/src/ServiceStack.Text/Common/JsWriter.cs
+++ b/src/ServiceStack.Text/Common/JsWriter.cs
@@ -394,7 +394,7 @@ namespace ServiceStack.Text.Common
                         mapTypeArgs[0], mapTypeArgs[1]);
 
                     var keyWriteFn = Serializer.GetWriteFn(mapTypeArgs[0]);
-                    var valueWriteFn = typeof(T) == typeof(JsonObject)
+                    var valueWriteFn = typeof(JsonObject).IsAssignableFrom(typeof(T))
                         ? JsonObject.WriteValue
                         : Serializer.GetWriteFn(mapTypeArgs[1]);
 

--- a/tests/ServiceStack.Text.Tests/JsonObjectTests.cs
+++ b/tests/ServiceStack.Text.Tests/JsonObjectTests.cs
@@ -328,5 +328,26 @@ namespace ServiceStack.Text.Tests
             Assert.That(listList, Is.EquivalentTo(new[]{ "foo", "bar", "qux" }));
         }
 
+        [Test]
+        public void Can_deserialize_Inherited_JSON_Object()
+        {
+            var jsonValue = "{\"test\":[\"Test1\",\"Test Two\"]}";
+
+            var jsonObject = JsonSerializer.DeserializeFromString<JsonObject>(jsonValue);
+            var inheritedJsonObject = JsonSerializer.DeserializeFromString<InheritedJsonObject>(jsonValue);
+
+            string testString = jsonObject.Child("test");
+            string inheritedTestString = inheritedJsonObject.Child("test");
+
+            Assert.AreEqual(testString, inheritedTestString);
+
+            var serializedJsonObject = JsonSerializer.SerializeToString<JsonObject>(jsonObject);
+            var serializedInheritedJsonObject = JsonSerializer.SerializeToString<InheritedJsonObject>(inheritedJsonObject);
+
+            Assert.AreEqual(serializedJsonObject, serializedInheritedJsonObject);
+        }
+        
+        public class InheritedJsonObject : JsonObject { }
+
     }
 }


### PR DESCRIPTION
For a project that creates a type which inherits from ServiceStack.Text's JsonObject, the inherited object is treated differently than the base object because of hard-coded equality comparisons. 

This PR allows projects to create inherited JsonObject types which perform identically to the JsonObject base class.

This PR could replace the existing code in the DeserializeDictionary class, but I just added my changes to minimize impact.

I have verified that this PR fixes the issue in my project, but I did not add a unit test because of the complication in replicating it generically outside my project. Let me know if you have any questions.