### PR TITLE
 Support nested dictionaries in FromObjectDictionary through recursion 

### DIFF
--- a/src/ServiceStack.Text/PlatformExtensions.cs
+++ b/src/ServiceStack.Text/PlatformExtensions.cs
@@ -628,6 +628,11 @@ namespace ServiceStack
                 if (SetValueFn == null)
                     return;
 
+                if (value is IReadOnlyDictionary<string, object> dictionary)
+                {
+                    value = dictionary.FromObjectDictionary(Type);
+                }
+
                 if (!Type.IsInstanceOfType(value))
                 {
                     lock (this)

--- a/src/ServiceStack.Text/TranslateListWithElements.cs
+++ b/src/ServiceStack.Text/TranslateListWithElements.cs
@@ -102,12 +102,8 @@ namespace ServiceStack.Text
             if (fromElType == null || toElType == null)
                 return null;
 
-            if (fromElType == typeof(object) || toElType.IsAssignableFrom(fromElType))
-                return TranslateToGenericICollectionCache(fromValue, toPropertyType, toElType);
-
-            return null;
+            return TranslateToGenericICollectionCache(fromValue, toPropertyType, toElType);
         }
-
     }
 
     public class ConvertibleTypeKey

--- a/src/ServiceStack.Text/TranslateListWithElements.cs
+++ b/src/ServiceStack.Text/TranslateListWithElements.cs
@@ -199,7 +199,15 @@ namespace ServiceStack.Text
             var to = (ICollection<T>)CreateInstance(toInstanceOfType);
             foreach (var item in fromList)
             {
-                to.Add((T)item);
+                if (item is IReadOnlyDictionary<string, object> dictionary)
+                {
+                    var convertedItem = dictionary.FromObjectDictionary<T>();
+                    to.Add(convertedItem);
+                }
+                else
+                {
+                    to.Add((T)item);
+                }
             }
             return to;
         }

--- a/tests/ServiceStack.Text.Tests/AutoMappingObjectDictionaryTests.cs
+++ b/tests/ServiceStack.Text.Tests/AutoMappingObjectDictionaryTests.cs
@@ -405,6 +405,146 @@ namespace ServiceStack.Text.Tests
             Assert.That(to == dict);
         }
         
+        [Test]
+        public void Can_convert_inner_dictionary()
+        {
+            var map = new Dictionary<string, object>
+            {
+                { "FirstName", "Foo" },
+                { "LastName", "Bar" },
+                { "Car", new Dictionary<string, object>
+                {
+                    { "Name", "Tesla" },
+                    { "Age", 2 }
+                }}
+            };
+
+            var user = map.FromObjectDictionary<User>();
+
+            Assert.That(user.FirstName, Is.EqualTo("Foo"));
+            Assert.That(user.LastName, Is.EqualTo("Bar"));
+            Assert.That(user.Car, Is.Not.Null);
+            Assert.That(user.Car.Name, Is.EqualTo("Tesla"));
+            Assert.That(user.Car.Age, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Can_convert_inner_collection_of_dictionaries()
+        {
+            var map = new Dictionary<string, object>
+            {
+                { "Name", "Tesla" },
+                { "Age", "2" },
+                { "Specs", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "Model"},
+                        {"Value", "S"}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "Engine"},
+                        {"Value", "Electric"}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "Color"},
+                        {"Value", "Red"}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "PowerKW"},
+                        {"Value", 285}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "TorqueNm"},
+                        {"Value", 430}
+                    },
+                }}
+            };
+
+            var carWithSpecs = map.FromObjectDictionary<CarWithSpecs>();
+
+            Assert.That(carWithSpecs.Name, Is.EqualTo("Tesla"));
+            Assert.That(carWithSpecs.Age, Is.EqualTo(2));
+            Assert.That(carWithSpecs.Specs.Count, Is.EqualTo(5));
+            var model = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "Model");
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.Value, Is.EqualTo("S"));
+            var engine = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "Engine");
+            Assert.That(engine, Is.Not.Null);
+            Assert.That(engine.Value, Is.EqualTo("Electric"));
+            var color = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "Color");
+            Assert.That(color, Is.Not.Null);
+            Assert.That(color.Value, Is.EqualTo("Red"));
+            var power = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "PowerKW");
+            Assert.That(power, Is.Not.Null);
+            Assert.That(power.Value, Is.EqualTo("285"));
+            var torque = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "TorqueNm");
+            Assert.That(torque, Is.Not.Null);
+            Assert.That(torque.Value, Is.EqualTo("430"));
+        }
+
+        [Test]
+        public void Can_convert_inner_array_of_dictionaries()
+        {
+            var map = new Dictionary<string, object>
+            {
+                { "Name", "Tesla" },
+                { "Age", "2" },
+                { "Specs", new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "Model"},
+                        {"Value", "S"}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "Engine"},
+                        {"Value", "Electric"}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "Color"},
+                        {"Value", "Red"}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "PowerKW"},
+                        {"Value", 285}
+                    },
+                    new Dictionary<string, object>
+                    {
+                        {"Item", "TorqueNm"},
+                        {"Value", 430}
+                    },
+                }}
+            };
+
+            var carWithSpecs = map.FromObjectDictionary<CarWithSpecs>();
+
+            Assert.That(carWithSpecs.Name, Is.EqualTo("Tesla"));
+            Assert.That(carWithSpecs.Age, Is.EqualTo(2));
+            Assert.That(carWithSpecs.Specs.Count, Is.EqualTo(5));
+            var model = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "Model");
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.Value, Is.EqualTo("S"));
+            var engine = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "Engine");
+            Assert.That(engine, Is.Not.Null);
+            Assert.That(engine.Value, Is.EqualTo("Electric"));
+            var color = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "Color");
+            Assert.That(color, Is.Not.Null);
+            Assert.That(color.Value, Is.EqualTo("Red"));
+            var power = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "PowerKW");
+            Assert.That(power, Is.Not.Null);
+            Assert.That(power.Value, Is.EqualTo("285"));
+            var torque = carWithSpecs.Specs.SingleOrDefault(s => s.Item == "TorqueNm");
+            Assert.That(torque, Is.Not.Null);
+            Assert.That(torque.Value, Is.EqualTo("430"));
+        }
     }
 
 

--- a/tests/ServiceStack.Text.Tests/AutoMappingTests.cs
+++ b/tests/ServiceStack.Text.Tests/AutoMappingTests.cs
@@ -43,6 +43,17 @@ namespace ServiceStack.Text.Tests
         public string Custom { get; set; }
     }
 
+    public class CarWithSpecs : Car
+    {
+        public List<CarSpec> Specs { get; set; }
+    }
+
+    public class CarSpec
+    {
+        public string Item { get; set; }
+        public string Value { get; set; }
+    }
+
     public class UserDto
     {
         public string FirstName { get; set; }


### PR DESCRIPTION
Disclosure: I'm working on [Neo4jMapper](https://github.com/neildobson-au/Neo4jMapper) which uses ServiceStack.Text to read data from Neo4j using their low-level [driver](https://github.com/neo4j/neo4j-dotnet-driver) and convert to POCOs. However due to the nature of graph databases, the data structures are complex, and the return types have nested dictionaries. 