### PR TITLE
Fixed erroneous recursive call in JsvTypeSerializer.EatMapStartChar

### DIFF
--- a/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
+++ b/src/ServiceStack.Text/Jsv/JsvTypeSerializer.cs
@@ -280,7 +280,7 @@ namespace ServiceStack.Text.Jsv
 
         public ReadOnlySpan<char> EatTypeValue(ReadOnlySpan<char> value, ref int i) => EatValue(value, ref i);
 
-        public bool EatMapStartChar(string value, ref int i) => EatMapStartChar(value, ref i);
+        public bool EatMapStartChar(string value, ref int i) => EatMapStartChar(value.AsSpan(), ref i);
 
         public bool EatMapStartChar(ReadOnlySpan<char> value, ref int i)
         {


### PR DESCRIPTION
This PR fixes a minor bug in JsvTypeSerializer which leads to a StackOverflow exception due an infinite recursive call.