### PR TITLE
Optimize PlatformExtensions HasAttributeCached using an immutableDictionary

### DIFF
--- a/src/ServiceStack.Text/ServiceStack.Text.csproj
+++ b/src/ServiceStack.Text/ServiceStack.Text.csproj
@@ -18,16 +18,19 @@
     <Reference Include="System.Configuration" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>

--- a/src/ServiceStack.Text/ServiceStack.Text.csproj
+++ b/src/ServiceStack.Text/ServiceStack.Text.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>


### PR DESCRIPTION
#### What this PR does ?
Replaces the Dictionary in PlatformExtensions HasAttributeCached by an ImmutablePerformance, lowering caching computation cost.

#### Potential issue
This PR adds a dependency in System.Collections.Immutable https://docs.microsoft.com/en-us/dotnet/api/system.collections.immutable?view=netcore-3.0 which is part of .NET Core but not .NET Framework.

#### Context
When migrating from 5.4 to 5.7, I encountered a performance issue which after investigation is due to this commit https://github.com/ServiceStack/ServiceStack.Text/commit/6f5e256a0d3cf8de2d57597154773349da091540#diff-d4adc4d0360bc8a1d423eea315dad214R93 which seems to increase the cost of the lock-free create-copy-and-swap strategy used to add a new entry in the HasAttribute cache.

The reason being, the addition of a new element triggers the copy of the current dictionary, hence performing n insertions in a new instance. Overall, caching n elements hence requires ~n^2/2 insertions (and n allocations of Dictionary).
Using ImmutableDictionary, it is possible to lower this cost due to its internal strategy to share key-value-pairs between an instance and the new one returned by Add. We hence end up with ~ n insertions.

To check this behavior, I used DotTrace to profile a NUnit test which sets up a database in my application, and hence uses several table types (and triggers the caching of ~30k MemberInfo).

Before the change : (425s)
![image](https://user-images.githubusercontent.com/6624646/66267598-53654f00-e865-11e9-8352-b12ce6aa08ce.png)

After the change : (133s)
![image](https://user-images.githubusercontent.com/6624646/66267614-83aced80-e865-11e9-9ec2-63efb77a9f9a.png)

As it can be seen, all the overhead of the caching (EqualityComparer, Insert, etc...) has disappeared, the cost of ImmutableCollection being contained in the 0.54% of Collections (0.01% aside ConcurrentDictionary, List, etc...)

