### PR TITLE
Fix List primitive to/from CSV so that same input gets the same output.

### DIFF
--- a/src/ServiceStack.Text/CsvReader.cs
+++ b/src/ServiceStack.Text/CsvReader.cs
@@ -272,6 +272,21 @@ namespace ServiceStack.Text
             return row;
         }
 
+        private static List<T> ParseSingleRow(string row, Type recordType)
+        {
+            var results = new List<T>();
+            var itemRows = CsvReader.ParseFields(row);
+            foreach (var itemRow in itemRows)
+            {
+                var to = recordType == typeof(string)
+                    ? (T)(object)itemRow
+                    : TypeSerializer.DeserializeFromString<T>(itemRow);
+                
+                results.Add(to);
+            }
+            return results;
+        }
+
         public static List<T> GetRows(IEnumerable<string> records)
         {
             var rows = new List<T>();
@@ -358,6 +373,11 @@ namespace ServiceStack.Text
             if (!CsvConfig<T>.OmitHeaders || Headers.Count == 0)
             {
                 headers = CsvReader.ParseFields(rows[0], s => s.Trim());
+            }
+
+            if (typeof(T).IsValueType || (typeof(T) == typeof(string)) && rows.Count == 1)
+            {
+                return ParseSingleRow(rows[0], typeof(T));
             }
 
             if (typeof(T).IsValueType || typeof(T) == typeof(string))

--- a/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
+++ b/tests/ServiceStack.Text.Tests/CsvTests/ObjectSerializerTests.cs
@@ -191,6 +191,40 @@ namespace ServiceStack.Text.Tests.CsvTests
             Assert.That(des[0].Prop4, Is.EqualTo(src[0].Prop4));
             Assert.That(des[0].Prop5, Is.EqualTo(src[0].Prop5));
         }
+
+        [Test]
+        public void Can_serialize_csv_and_deserialize_List_string()
+        {
+            var list = new List<string>
+            {
+                "one",
+                "two",
+                "three"
+            };
+
+            var flatList = list.ToCsv();
+
+            var originalList = flatList.FromCsv<List<string>>();
+
+            Assert.That(originalList.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Can_serialize_csv_and_deserialize_List_primitives()
+        {
+            var list = new List<int>
+            {
+                1,
+                2,
+                3
+            };
+
+            var flatList = list.ToCsv();
+
+            var originalList = flatList.FromCsv<List<int>>();
+
+            Assert.That(originalList.Count, Is.EqualTo(3));
+        }
     }
 
     public class POCO


### PR DESCRIPTION
Fixing issue where `List<string> values` couldn't go `ToCsv()` and back `FromCsv<List<string>>()` consistently.

Eg,

```csharp
var list = new List<string>
{
    "one",
    "two",
    "three"
};

var flatList = list.ToCsv();
var originalList = flatList.FromCsv<List<string>>();
```

Where `originalList` would have a 1 element rather than 3 elements like the original input.