### PR TITLE
Bug Report: StringExtensions.ReplaceAll enters infinite loop.

### DIFF
--- a/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
+++ b/tests/ServiceStack.Text.Tests/StringExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace ServiceStack.Text.Tests
@@ -360,6 +361,20 @@ namespace ServiceStack.Text.Tests
         public void Does_ReplaceAll_from_Start()
         {
             Assert.That("/images".ReplaceAll("/",""), Is.EqualTo("images"));
+        }
+
+        [Test]
+        public void Does_ReplaceAll_Avoid_Infinite_Loops()
+        {
+            var input = "image";
+            var output = input;
+
+            Task.Factory.StartNew(() =>
+            {
+                output = input.ReplaceAll("image", "images");
+            }).Wait(TimeSpan.FromSeconds(1));
+
+            Assert.That(output, Is.EqualTo("images"));
         }
 
         [TestCase("", ExpectedResult = "/")]


### PR DESCRIPTION
When replacing x with something that contains x. New test case in StringExtensionsTests fails.

I wasn't sure how best to represent this issue in a unit test, but this is what I went with.