### PR TITLE
Support uppercase file extentions

### DIFF
--- a/src/ServiceStack.Text/HttpUtils.cs
+++ b/src/ServiceStack.Text/HttpUtils.cs
@@ -1,4 +1,4 @@
-﻿//Copyright (c) ServiceStack, Inc. All Rights Reserved.
+//Copyright (c) ServiceStack, Inc. All Rights Reserved.
 //License: https://raw.github.com/ServiceStack/ServiceStack/master/license.txt
 
 using System;
@@ -1556,7 +1556,7 @@ namespace ServiceStack
             if (string.IsNullOrEmpty(fileNameOrExt))
                 throw new ArgumentNullException(nameof(fileNameOrExt));
 
-            var fileExt = fileNameOrExt.LastRightPart('.');
+            var fileExt = fileNameOrExt.LastRightPart('.').ToLower();
             if (ExtensionMimeTypes.TryGetValue(fileExt, out var mimeType))
             {
                 return mimeType;


### PR DESCRIPTION
I've noticed that uppercase extensions of binary files are treated as text. I've encountered that in the ServiceStack.Aws project.
The result was that files named like IMG_123**.JPG** were returning different content lengths when renamed to IMG_123**.jpg** (on S3)
