### PR TITLE
Update DateTimeExtensions.cs DateTimeOffset

### DIFF
--- a/src/ServiceStack.Text/DateTimeExtensions.cs
+++ b/src/ServiceStack.Text/DateTimeExtensions.cs
@@ -45,6 +45,12 @@ namespace ServiceStack.Text
         {
             return (dateTime.ToStableUniversalTime().Ticks - UnixEpoch) / TimeSpan.TicksPerMillisecond;
         }
+        
+        public static long ToUnixTimeMs(this DateTimeOffset dateTimeOffset)
+        {
+            var universal = ToDateTimeSinceUnixEpoch(dateTimeOffset);
+            return (long)universal.TotalMilliseconds;
+        }
 
         public static long ToUnixTimeMs(this DateTime dateTime)
         {
@@ -56,6 +62,9 @@ namespace ServiceStack.Text
         {
             return (dateTime.ToDateTimeSinceUnixEpoch().Ticks) / TimeSpan.TicksPerSecond;
         }
+        
+        private static TimeSpan ToDateTimeSinceUnixEpoch(this DateTimeOffset dateTimeOffset)
+            => ToDateTimeSinceUnixEpoch(dateTimeOffset.UtcDateTime);
 
         private static TimeSpan ToDateTimeSinceUnixEpoch(this DateTime dateTime)
         {


### PR DESCRIPTION
Include DateTimeOffset arg to extension method ToUnixTimeMs. Made the assumption to use 'UtcDateTime' to use original DateTime implementation. Possibly a better way exists.
Note 1:  Due to `private static ToDateTimeSinceUnixEpoch` and `internal DateTimeSerializer.LocalTimeZone` had to re-implement to get it to work.
Note 2: `ToUnixTimeMsAlt` should probably also have a DateTimeOffset implementation, but I did not implement.